### PR TITLE
fix(aws-alb): parse multi-cert chains from X-Amzn-Mtls-Clientcert

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -99,9 +99,24 @@ export function parseUrlPemAws(headerValue) {
         // (mirrors parseBase64Der's chain handling for Traefik/Cloudflare).
         // Node's X509Certificate throws on multi-block input, so without this
         // split the entire request fails when AWS forwards a real chain.
-        const pemBlocks = pem.match(/-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g);
+        //
+        // Uses indexOf scanning rather than regex to avoid polynomial-time
+        // backtracking on adversarial input (e.g., many unterminated BEGIN
+        // markers). Total work is O(N) in the input length.
+        const pemBlocks = [];
+        const beginMarker = '-----BEGIN CERTIFICATE-----';
+        const endMarker = '-----END CERTIFICATE-----';
+        let scanPos = 0;
+        while (true) {
+            const begin = pem.indexOf(beginMarker, scanPos);
+            if (begin === -1) {break;}
+            const end = pem.indexOf(endMarker, begin + beginMarker.length);
+            if (end === -1) {break;}
+            pemBlocks.push(pem.substring(begin, end + endMarker.length));
+            scanPos = end + endMarker.length;
+        }
 
-        if (!pemBlocks || pemBlocks.length === 0) {
+        if (pemBlocks.length === 0) {
             return null;
         }
 

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -93,7 +93,36 @@ export function parseUrlPemAws(headerValue) {
         // Must escape before decodeURIComponent or + becomes space
         const escaped = headerValue.replace(/\+/g, '%2B');
         const pem = decodeURIComponent(escaped);
-        return pemToCertificate(pem);
+
+        // AWS sends the full chain as concatenated PEM blocks. Split into
+        // individual blocks and parse each, then link via issuerCertificate
+        // (mirrors parseBase64Der's chain handling for Traefik/Cloudflare).
+        // Node's X509Certificate throws on multi-block input, so without this
+        // split the entire request fails when AWS forwards a real chain.
+        const pemBlocks = pem.match(/-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g);
+
+        if (!pemBlocks || pemBlocks.length === 0) {
+            return null;
+        }
+
+        const certs = pemBlocks.map(block => {
+            try {
+                return pemToCertificate(block);
+            } catch {
+                return null;
+            }
+        }).filter(Boolean);
+
+        if (certs.length === 0) {
+            return null;
+        }
+
+        // Link the cert chain via issuerCertificate
+        for (let i = 0; i < certs.length - 1; i++) {
+            certs[i].issuerCertificate = certs[i + 1];
+        }
+
+        return certs[0];
     } catch {
         return null;
     }

--- a/test/test-unit-extractor.js
+++ b/test/test-unit-extractor.js
@@ -450,6 +450,72 @@ describe('extractClientCertificate', () => {
         // (The parser may or may not include it depending on the cert)
       });
 
+      it('should preserve chain via issuerCertificate when aws-alb sends multi-PEM chain with includeChain', async () => {
+        const selfsigned = (await import('selfsigned')).default;
+        const leaf = await selfsigned.generate(
+          [{ name: 'commonName', value: 'leaf.example.com' }],
+          { algorithm: 'sha256', keySize: 2048, days: 1 }
+        );
+        const intermediate = await selfsigned.generate(
+          [{ name: 'commonName', value: 'Intermediate CA' }],
+          { algorithm: 'sha256', keySize: 2048, days: 1 }
+        );
+
+        // AWS sends multi-cert chains as concatenated URL-encoded PEM blocks
+        // (per X-Amzn-Mtls-Clientcert format in API Gateway / ALB docs)
+        const chainedPem = leaf.cert + intermediate.cert;
+        const encodedCert = encodeURIComponent(chainedPem);
+
+        const req = {
+          headers: {
+            'x-amzn-mtls-clientcert': encodedCert,
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'aws-alb',
+          includeChain: true,
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.strictEqual(result.certificate.subject.CN, 'leaf.example.com');
+        assert.ok(result.certificate.issuerCertificate, 'leaf should have issuerCertificate populated from intermediate');
+        assert.strictEqual(result.certificate.issuerCertificate.subject.CN, 'Intermediate CA');
+      });
+
+      it('should strip issuerCertificate by default from aws-alb multi-PEM chain', async () => {
+        const selfsigned = (await import('selfsigned')).default;
+        const leaf = await selfsigned.generate(
+          [{ name: 'commonName', value: 'leaf.example.com' }],
+          { algorithm: 'sha256', keySize: 2048, days: 1 }
+        );
+        const intermediate = await selfsigned.generate(
+          [{ name: 'commonName', value: 'Intermediate CA' }],
+          { algorithm: 'sha256', keySize: 2048, days: 1 }
+        );
+
+        const chainedPem = leaf.cert + intermediate.cert;
+        const encodedCert = encodeURIComponent(chainedPem);
+
+        const req = {
+          headers: {
+            'x-amzn-mtls-clientcert': encodedCert,
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'aws-alb',
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.strictEqual(result.certificate.subject.CN, 'leaf.example.com');
+        assert.strictEqual(result.certificate.issuerCertificate, undefined);
+      });
+
       it('should strip issuerCertificate from base64-der chained cert by default', async () => {
         // Generate two certs to create a chain
         const selfsigned = (await import('selfsigned')).default;

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -170,6 +170,30 @@ describe('parsers module', () => {
                 .replace(/%2F/g, '/');
             assert.equal(parseUrlPemAws(encoded), null);
         });
+
+        it('should skip a malformed PEM block in a chain and return the valid leaf', () => {
+            // Valid leaf followed by a syntactically-correct PEM frame containing invalid base64.
+            // The leaf should still parse; the bad block is silently dropped.
+            const invalidBlock = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64\n-----END CERTIFICATE-----\n';
+            const encoded = encodeAsAwsAlb(testPem + invalidBlock);
+            const cert = parseUrlPemAws(encoded);
+
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+        });
+
+        it('should return null when every PEM block in a chain is malformed', () => {
+            const invalidBlock1 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_1\n-----END CERTIFICATE-----\n';
+            const invalidBlock2 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_2\n-----END CERTIFICATE-----\n';
+            const encoded = encodeAsAwsAlb(invalidBlock1 + invalidBlock2);
+
+            assert.equal(parseUrlPemAws(encoded), null);
+        });
+
+        it('should return null when URL encoding is malformed', () => {
+            // %G0 is not a valid percent-encoded sequence; decodeURIComponent throws.
+            assert.equal(parseUrlPemAws('%G0'), null);
+        });
     });
 
     describe('parseXfcc (Envoy format)', () => {

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -194,6 +194,18 @@ describe('parsers module', () => {
             // %G0 is not a valid percent-encoded sequence; decodeURIComponent throws.
             assert.equal(parseUrlPemAws('%G0'), null);
         });
+
+        it('should stop scanning at a BEGIN marker with no matching END marker', () => {
+            // A valid leaf cert followed by a truncated BEGIN with no END.
+            // The scanner should return the leaf and silently ignore the trailing
+            // unterminated block rather than scanning forever.
+            const truncated = '-----BEGIN CERTIFICATE-----\nMIIBkTCCATug==\n';
+            const encoded = encodeAsAwsAlb(testPem + truncated);
+            const cert = parseUrlPemAws(encoded);
+
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+        });
     });
 
     describe('parseXfcc (Envoy format)', () => {


### PR DESCRIPTION
## Summary
- AWS API Gateway and ALB send the full client cert chain as concatenated URL-encoded PEM blocks in `X-Amzn-Mtls-Clientcert`. Node's `X509Certificate` constructor throws on multi-block input, so `parseUrlPemAws` returned `null` for any AWS deployment with intermediate CAs, silently failing authentication entirely.
- Splits the decoded PEM blob on PEM block boundaries and parses each cert, then links via `issuerCertificate` (mirrors the chain pattern in `parseBase64Der`).
- Two integration tests exercise the AWS-documented multi-PEM format end-to-end (with and without `includeChain`). Three parser-level tests cover the new edge cases: chain with one bad block, chain with all bad blocks, and malformed URL encoding.
- 100% coverage maintained. All 374 tests pass.

Fixes #82

Note: `parseUrlPem` (used for nginx/HAProxy URL-PEM where `+` decodes to space) likely has the same bug and is out of scope for this PR. Worth a follow-up if anyone uses chain forwarding behind those proxies.