### PR TITLE
chore(release): v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2026-04-28
+
+### Fixed
+
+- **`parseUrlPemAws` chain handling for AWS API Gateway and ALB** ([#82](https://github.com/tgies/client-certificate-auth/issues/82), [#83](https://github.com/tgies/client-certificate-auth/pull/83)) — AWS sends the full client cert chain as concatenated URL-encoded PEM blocks in `X-Amzn-Mtls-Clientcert`. Node's `X509Certificate` constructor throws on multi-block PEM input, so `parseUrlPemAws` was returning `null` for any AWS deployment with intermediate CAs, silently failing authentication entirely. The parser now scans the decoded blob for PEM block boundaries via `indexOf` (O(N) in input length) and links the chain via `issuerCertificate`, mirroring the chain handling in `parseBase64Der` for Traefik and Cloudflare.
+
+### Tests
+
+- Added integration tests in `test-unit-extractor.js` exercising the AWS-documented multi-PEM format end-to-end (with and without `includeChain`).
+- Added parser-level tests in `test-unit-parsers.js` for the new chain-parsing path: a chain with one bad block, a chain where every block is bad, malformed URL encoding, and a truncated final block with no END marker.
+
 ## [1.3.2] - 2026-02-23
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client-certificate-auth",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client-certificate-auth",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^20.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-certificate-auth",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Express/Connect middleware for mTLS client certificate authentication with reverse proxy support (AWS ALB, Envoy, Cloudflare, Traefik)",
   "homepage": "https://github.com/tgies/client-certificate-auth",
   "bugs": {


### PR DESCRIPTION
## Summary
- Patch release for [#83](https://github.com/tgies/client-certificate-auth/pull/83) - fixes silent authentication failure for AWS API Gateway / ALB users with multi-cert client certificate chains.
- Bumps `package.json` and `package-lock.json` to 1.3.3, prepends a CHANGELOG entry.
- After merge: tag `v1.3.3` and push to trigger the publish workflow (`npm publish --provenance` + GitHub release).