### PR TITLE
fix(xfcc): chain multi-block PEM and prefer Chain over Cert

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -60,7 +60,7 @@ export const PRESETS = {
  * @returns {PeerCertificate | null} Parsed certificate or null on failure
  */
 export function parseUrlPem(headerValue) {
-    // Stryker disable next-line BlockStatement: falsy input falls through to try-catch → same null return
+    // Stryker disable next-line BlockStatement,ConditionalExpression: falsy input falls through to try-catch → same null return
     if (!headerValue) {
         return null;
     }
@@ -83,7 +83,9 @@ export function parseUrlPem(headerValue) {
  * @returns {string[]} Individual PEM blocks (empty array if none found)
  */
 function splitPemBlocks(pem) {
+    // Stryker disable next-line ArrayDeclaration: sentinel-array mutant pushes a non-PEM string that pemToCertificate rejects and .filter(Boolean) drops downstream — same chain output
     const blocks = [];
+    // Stryker disable next-line StringLiteral: empty beginMarker → indexOf returns scanPos every iteration; END markers still bracket the same blocks correctly
     const beginMarker = '-----BEGIN CERTIFICATE-----';
     const endMarker = '-----END CERTIFICATE-----';
     let scanPos = 0;
@@ -93,6 +95,7 @@ function splitPemBlocks(pem) {
         const end = pem.indexOf(endMarker, begin + beginMarker.length);
         if (end === -1) {break;}
         blocks.push(pem.substring(begin, end + endMarker.length));
+        // Stryker disable next-line ArithmeticOperator: end-endMarker.length backs up before the END marker, but the next BEGIN is past it so indexOf still advances correctly
         scanPos = end + endMarker.length;
     }
     return blocks;
@@ -114,6 +117,7 @@ function splitPemBlocks(pem) {
  */
 function chainFromMultiBlockPem(pem) {
     const pemBlocks = splitPemBlocks(pem);
+    // Stryker disable next-line BlockStatement,ConditionalExpression: short-circuit; falling through hits the next certs.length===0 check with the same null result
     if (pemBlocks.length === 0) {
         return null;
     }
@@ -122,6 +126,7 @@ function chainFromMultiBlockPem(pem) {
         try {
             return pemToCertificate(block);
         } catch {
+            // Stryker disable next-line BlockStatement: empty catch returns undefined which .filter(Boolean) drops alongside null — same chain output
             return null;
         }
     }).filter(Boolean);
@@ -149,7 +154,7 @@ function chainFromMultiBlockPem(pem) {
  * @returns {PeerCertificate | null} Parsed certificate or null on failure
  */
 export function parseUrlPemAws(headerValue) {
-    // Stryker disable next-line BlockStatement: falsy input falls through to try-catch → same null return
+    // Stryker disable next-line BlockStatement,ConditionalExpression: falsy input falls through to try-catch → same null return
     if (!headerValue) {
         return null;
     }
@@ -177,7 +182,7 @@ export function parseUrlPemAws(headerValue) {
  * @returns {PeerCertificate | null} Parsed certificate or null on failure
  */
 export function parseXfcc(headerValue) {
-    // Stryker disable next-line BlockStatement: falsy input falls through to try-catch → same null return
+    // Stryker disable next-line BlockStatement,ConditionalExpression: falsy input falls through to try-catch → same null return
     if (!headerValue) {
         return null;
     }
@@ -220,7 +225,9 @@ export function parseXfcc(headerValue) {
             let value = pair.substring(eqIndex + 1).trim();
 
             if (key === 'Cert' || key === 'Chain') {
+                // Stryker disable next-line LogicalOperator,MethodExpression,StringLiteral,BlockStatement: quote-stripping mutations are equivalent given the secondary unbalanced-quote reject below and lenient PEM marker scan downstream — broken quotes either trigger reject or produce a stripped value that fails to parse, both yielding null
                 if (value.startsWith('"') && value.endsWith('"')) {
+                    // Stryker disable next-line MethodExpression: skipping the slice leaves quotes around the value; PEM marker scan still finds BEGIN/END inside them and parses the cert content correctly — equivalent for tests
                     value = value.slice(1, -1);
                 } else if (value.startsWith('"') || value.endsWith('"')) {
                     // Unbalanced quote indicates malformed XFCC. Reject rather
@@ -236,6 +243,7 @@ export function parseXfcc(headerValue) {
         }
 
         const value = chainValue ?? certValue;
+        // Stryker disable next-line BlockStatement,ConditionalExpression: short-circuit; falling through with null hands "null" string to chainFromMultiBlockPem which finds no PEM markers and returns null
         if (!value) {
             return null;
         }
@@ -257,7 +265,7 @@ export function parseXfcc(headerValue) {
  * @returns {PeerCertificate | null} Parsed certificate or null on failure
  */
 export function parseBase64Der(headerValue) {
-    // Stryker disable next-line BlockStatement: falsy input falls through to try-catch → same null return
+    // Stryker disable next-line BlockStatement,ConditionalExpression: falsy input falls through to try-catch → same null return
     if (!headerValue) {
         return null;
     }
@@ -304,7 +312,7 @@ export function parseBase64Der(headerValue) {
  * @returns {PeerCertificate | null} Parsed certificate or null on failure
  */
 export function parseRfc9440(headerValue) {
-    // Stryker disable next-line BlockStatement: falsy input falls through to try-catch → same null return
+    // Stryker disable next-line BlockStatement,ConditionalExpression: falsy input falls through to try-catch → same null return
     if (!headerValue) {
         return null;
     }

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -74,10 +74,76 @@ export function parseUrlPem(headerValue) {
 }
 
 /**
+ * Split a string of concatenated PEM CERTIFICATE blocks into an array of
+ * individual PEM strings. Uses indexOf scanning (O(N) in input length) rather
+ * than regex to avoid polynomial-time backtracking on adversarial input
+ * (e.g., many unterminated BEGIN markers).
+ *
+ * @param {string} pem - Concatenated PEM blocks
+ * @returns {string[]} Individual PEM blocks (empty array if none found)
+ */
+function splitPemBlocks(pem) {
+    const blocks = [];
+    const beginMarker = '-----BEGIN CERTIFICATE-----';
+    const endMarker = '-----END CERTIFICATE-----';
+    let scanPos = 0;
+    while (true) {
+        const begin = pem.indexOf(beginMarker, scanPos);
+        if (begin === -1) {break;}
+        const end = pem.indexOf(endMarker, begin + beginMarker.length);
+        if (end === -1) {break;}
+        blocks.push(pem.substring(begin, end + endMarker.length));
+        scanPos = end + endMarker.length;
+    }
+    return blocks;
+}
+
+/**
+ * Parse a multi-block PEM blob into a chained PeerCertificate. Splits the
+ * input into individual blocks, parses each, drops blocks that fail to
+ * parse, and links the remainder via issuerCertificate.
+ *
+ * Used by parsers whose proxies forward the full chain in a single field
+ * (parseUrlPemAws, parseXfcc Chain). Without explicit chain linking, calling
+ * X509Certificate() on a multi-block PEM returns just the leaf with no
+ * issuerCertificate (toLegacyObject drops the property), silently losing
+ * chain information for `includeChain: true` consumers.
+ *
+ * @param {string} pem - Concatenated PEM blocks
+ * @returns {PeerCertificate | null} Leaf cert with chain via issuerCertificate, or null if no blocks parse
+ */
+function chainFromMultiBlockPem(pem) {
+    const pemBlocks = splitPemBlocks(pem);
+    if (pemBlocks.length === 0) {
+        return null;
+    }
+
+    const certs = pemBlocks.map(block => {
+        try {
+            return pemToCertificate(block);
+        } catch {
+            return null;
+        }
+    }).filter(Boolean);
+
+    if (certs.length === 0) {
+        return null;
+    }
+
+    // Stryker disable next-line EqualityOperator: setting issuerCertificate = undefined on last cert is same as not setting it
+    for (let i = 0; i < certs.length - 1; i++) {
+        certs[i].issuerCertificate = certs[i + 1];
+    }
+
+    return certs[0];
+}
+
+/**
  * Parse URL-encoded PEM certificate with AWS ALB safe character handling.
  * AWS ALB uses +, =, / as safe characters (not encoded), but decodeURIComponent
- * interprets + as space, so we must escape it first.
- * 
+ * interprets + as space, so we must escape it first. AWS sends the full chain
+ * as concatenated PEM blocks, which we split and link via issuerCertificate.
+ *
  * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/mutual-authentication.html
  * @param {string} headerValue - AWS ALB URL-encoded PEM certificate
  * @returns {PeerCertificate | null} Parsed certificate or null on failure
@@ -93,51 +159,7 @@ export function parseUrlPemAws(headerValue) {
         // Must escape before decodeURIComponent or + becomes space
         const escaped = headerValue.replace(/\+/g, '%2B');
         const pem = decodeURIComponent(escaped);
-
-        // AWS sends the full chain as concatenated PEM blocks. Split into
-        // individual blocks and parse each, then link via issuerCertificate
-        // (mirrors parseBase64Der's chain handling for Traefik/Cloudflare).
-        // Node's X509Certificate throws on multi-block input, so without this
-        // split the entire request fails when AWS forwards a real chain.
-        //
-        // Uses indexOf scanning rather than regex to avoid polynomial-time
-        // backtracking on adversarial input (e.g., many unterminated BEGIN
-        // markers). Total work is O(N) in the input length.
-        const pemBlocks = [];
-        const beginMarker = '-----BEGIN CERTIFICATE-----';
-        const endMarker = '-----END CERTIFICATE-----';
-        let scanPos = 0;
-        while (true) {
-            const begin = pem.indexOf(beginMarker, scanPos);
-            if (begin === -1) {break;}
-            const end = pem.indexOf(endMarker, begin + beginMarker.length);
-            if (end === -1) {break;}
-            pemBlocks.push(pem.substring(begin, end + endMarker.length));
-            scanPos = end + endMarker.length;
-        }
-
-        if (pemBlocks.length === 0) {
-            return null;
-        }
-
-        const certs = pemBlocks.map(block => {
-            try {
-                return pemToCertificate(block);
-            } catch {
-                return null;
-            }
-        }).filter(Boolean);
-
-        if (certs.length === 0) {
-            return null;
-        }
-
-        // Link the cert chain via issuerCertificate
-        for (let i = 0; i < certs.length - 1; i++) {
-            certs[i].issuerCertificate = certs[i + 1];
-        }
-
-        return certs[0];
+        return chainFromMultiBlockPem(pem);
     } catch {
         return null;
     }
@@ -145,8 +167,11 @@ export function parseUrlPemAws(headerValue) {
 
 /**
  * Parse Envoy XFCC (X-Forwarded-Client-Cert) structured header format.
- * Format: Key=Value;Key=Value;... where Cert or Chain contains URL-encoded PEM.
- * 
+ * Format: Key=Value;Key=Value;... where Cert (single URL-encoded PEM) or
+ * Chain (URL-encoded multi-block PEM with the full chain incl. leaf) carry
+ * the certificate. When both are present we prefer Chain because it carries
+ * more information, and link the chain via issuerCertificate.
+ *
  * @see https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert
  * @param {string} headerValue - XFCC formatted header value
  * @returns {PeerCertificate | null} Parsed certificate or null on failure
@@ -176,8 +201,11 @@ export function parseXfcc(headerValue) {
         }
         const firstElement = headerValue.substring(0, endOfFirst);
 
-        // Parse key=value pairs separated by semicolons
+        // Parse key=value pairs separated by semicolons. Collect Cert and
+        // Chain values; prefer Chain when both are present.
         const pairs = firstElement.split(';');
+        let certValue = null;
+        let chainValue = null;
 
         for (const pair of pairs) {
             const eqIndex = pair.indexOf('=');
@@ -191,19 +219,29 @@ export function parseXfcc(headerValue) {
             // Stryker disable next-line MethodExpression: defensive normalization, no real proxy sends whitespace
             let value = pair.substring(eqIndex + 1).trim();
 
-            // Cert or Chain contain the certificate
             if (key === 'Cert' || key === 'Chain') {
-                // Remove surrounding quotes if present
                 if (value.startsWith('"') && value.endsWith('"')) {
                     value = value.slice(1, -1);
+                } else if (value.startsWith('"') || value.endsWith('"')) {
+                    // Unbalanced quote indicates malformed XFCC. Reject rather
+                    // than parse the cert content out of the broken wrapping.
+                    return null;
                 }
-
-                const pem = decodeURIComponent(value);
-                return pemToCertificate(pem);
+                if (key === 'Chain') {
+                    chainValue = value;
+                } else {
+                    certValue = value;
+                }
             }
         }
 
-        return null;
+        const value = chainValue ?? certValue;
+        if (!value) {
+            return null;
+        }
+
+        const pem = decodeURIComponent(value);
+        return chainFromMultiBlockPem(pem);
     } catch {
         return null;
     }

--- a/test/docker/backend/server.js
+++ b/test/docker/backend/server.js
@@ -12,19 +12,24 @@ import http from 'node:http';
 import clientCertificateAuth from 'client-certificate-auth';
 import { allowCN, allowIssuer, allOf, anyOf } from 'client-certificate-auth/helpers';
 
-// Path-based configuration
+// Path-based configuration. includeChain: true so the test can observe
+// whether the parser preserved the cert chain via issuerCertificate (the
+// extractor strips it by default).
 const PATH_CONFIGS = {
     '/nginx': {
         certificateHeader: 'x-ssl-client-cert',
         headerEncoding: 'url-pem',
+        includeChain: true,
     },
     '/envoy': {
         certificateHeader: 'x-forwarded-client-cert',
         headerEncoding: 'xfcc',
+        includeChain: true,
     },
     '/traefik': {
         certificateHeader: 'x-forwarded-tls-client-cert',
         headerEncoding: 'base64-der',
+        includeChain: true,
     },
 };
 
@@ -150,12 +155,17 @@ const server = http.createServer((req, res) => {
             }));
         } else {
             res.statusCode = 200;
+            const cert = req.clientCertificate;
             res.end(JSON.stringify({
                 success: true,
                 clientCN: req.clientCN,
                 proxyType: proxyType,
                 headerUsed: config.certificateHeader,
                 rawHeaderValue: req.headers[config.certificateHeader] || null,
+                // Chain diagnostics: set when the parser linked the issuer
+                // chain via issuerCertificate. null when chain info was lost.
+                issuerCN: cert?.issuer?.CN || null,
+                issuerCertificateSubjectCN: cert?.issuerCertificate?.subject?.CN || null,
             }));
         }
     });

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -6,11 +6,14 @@ services:
     networks:
       - proxy-net
 
-  # nginx with strict client cert verification (ssl_verify_client on)
+  # nginx with strict client cert verification (ssl_verify_client on).
+  # Host port left ephemeral so the suite is robust against host-side conflicts
+  # (some Windows services - e.g. iphlpsvc - claim 8443/8444). Discovered
+  # after `docker compose up` via `docker port`.
   nginx-strict:
     image: nginx:1.28.2-alpine
     ports:
-      - "8443:443"
+      - "443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ${CERTS_DIR}:/certs:ro
@@ -23,7 +26,7 @@ services:
   nginx-optional:
     image: nginx:1.28.2-alpine
     ports:
-      - "8444:443"
+      - "443"
     volumes:
       - ./nginx/nginx-optional.conf:/etc/nginx/nginx.conf:ro
       - ${CERTS_DIR}:/certs:ro
@@ -32,13 +35,30 @@ services:
     networks:
       - proxy-net
 
-  # Envoy proxy with XFCC header
+  # Envoy proxy with XFCC header. Standard config emits Cert= and Chain= -
+  # parseXfcc returns at the first Cert= match per Envoy's field order
+  # (Hash;Cert;Chain;Subject), so the multi-block Chain bug stays shadowed.
   envoy:
     image: envoyproxy/envoy:v1.37.0
     ports:
-      - "8445:443"
+      - "443"
     volumes:
       - ./envoy/envoy.yaml:/etc/envoy/envoy.yaml:ro
+      - ${CERTS_DIR}:/certs:ro
+    command: [ "envoy", "-c", "/etc/envoy/envoy.yaml" ]
+    depends_on:
+      - backend
+    networks:
+      - proxy-net
+
+  # Envoy with chain-only XFCC config (no Cert= field, only Chain=). Surfaces
+  # the parseXfcc multi-block PEM bug that the standard config shadows.
+  envoy-chain-only:
+    image: envoyproxy/envoy:v1.37.0
+    ports:
+      - "443"
+    volumes:
+      - ./envoy/envoy-chain-only.yaml:/etc/envoy/envoy.yaml:ro
       - ${CERTS_DIR}:/certs:ro
     command: [ "envoy", "-c", "/etc/envoy/envoy.yaml" ]
     depends_on:
@@ -50,7 +70,7 @@ services:
   traefik:
     image: traefik:v3.6.7
     ports:
-      - "8446:443"
+      - "443"
     volumes:
       - ./traefik/traefik.yaml:/etc/traefik/traefik.yaml:ro
       - ./traefik/dynamic.yaml:/etc/traefik/dynamic.yaml:ro

--- a/test/docker/envoy/envoy-chain-only.yaml
+++ b/test/docker/envoy/envoy-chain-only.yaml
@@ -12,9 +12,12 @@ static_resources:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                 stat_prefix: ingress_http
                 forward_client_cert_details: SANITIZE_SET
+                # Chain-only config: emits XFCC with Chain= (full chain, URL-encoded
+                # multi-block PEM) but no Cert= field. Surfaces parseXfcc multi-block
+                # handling - without a Cert= field to short-circuit on, the parser
+                # must process the multi-block Chain field correctly.
                 set_current_client_cert_details:
                   subject: true
-                  cert: true
                   chain: true
                 route_config:
                   name: local_route

--- a/test/docker/nginx/nginx.conf
+++ b/test/docker/nginx/nginx.conf
@@ -18,6 +18,7 @@ http {
         # Client certificate verification
         ssl_client_certificate /certs/ca.pem;
         ssl_verify_client on;
+        ssl_verify_depth 2;
 
         location /helpers/ {
             # Forward helpers routes with original path

--- a/test/test-e2e-proxies.js
+++ b/test/test-e2e-proxies.js
@@ -17,18 +17,40 @@ import https from 'node:https';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { generateMtlsCertificates, generateClientCertificate } from './test-helpers.js';
+import { generateMtlsCertificates, generateClientCertificate, generateIntermediateChain } from './test-helpers.js';
 import os from 'node:os';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DOCKER_DIR = path.join(__dirname, 'docker');
 
-// Configuration
-const NGINX_STRICT_PORT = 8443;   // nginx with ssl_verify_client on
-const NGINX_OPTIONAL_PORT = 8444; // nginx with ssl_verify_client optional_no_ca
-const ENVOY_PORT = 8445;          // Envoy with XFCC header
-const TRAEFIK_PORT = 8446;        // Traefik with PassTLSClientCert
+// Configuration. Host ports are assigned ephemerally by Docker (see
+// docker-compose.yml `ports: - "443"`) and discovered after compose up via
+// `docker compose port`. Keeps the suite robust against host-side port
+// conflicts (e.g. a Windows service holding 8443/8444).
+let NGINX_STRICT_PORT;
+let NGINX_OPTIONAL_PORT;
+let ENVOY_PORT;
+let ENVOY_CHAIN_ONLY_PORT;
+let TRAEFIK_PORT;
 const DOCKER_TIMEOUT = 120000;
+
+/**
+ * Resolve the host port that Docker Compose published for a service's
+ * container port. `docker compose port <svc> <port>` prints one line per
+ * binding ("0.0.0.0:32768", "[::]:32768"); take the first IPv4 binding.
+ */
+function getPublishedPort(service, containerPort, env) {
+    const out = execSync(`docker compose port ${service} ${containerPort}`, {
+        cwd: DOCKER_DIR,
+        env,
+        encoding: 'utf8',
+    });
+    const match = out.match(/^(?:0\.0\.0\.0|127\.0\.0\.1):(\d+)/m);
+    if (!match) {
+        throw new Error(`Could not resolve published port for ${service}:${containerPort} (got: ${out.trim()})`);
+    }
+    return parseInt(match[1], 10);
+}
 
 /**
  * Generate certificates and write them to disk for Docker containers.
@@ -128,10 +150,17 @@ const describeIfDocker = isDockerAvailable() ? describe : describe.skip;
 
 describeIfDocker('Reverse Proxy Integration Tests', () => {
     let certs;
+    let chainCerts; // { intermediate, client } where client is signed by intermediate, intermediate by certs.ca
+    let chainClientPresentedCert; // [client, intermediate] PEMs concatenated for TLS handshake
 
     beforeAll(async () => {
         // Generate certificates
         certs = await generateAndWriteCertificates();
+
+        // Generate a 3-tier chain (root=certs.ca -> intermediate -> chain client)
+        // so we can exercise multi-block PEM forwarding through the proxies.
+        chainCerts = await generateIntermediateChain(certs.ca);
+        chainClientPresentedCert = chainCerts.client.cert + '\n' + chainCerts.intermediate.cert;
 
         // Build and start Docker Compose
         console.log('Starting Docker Compose...');
@@ -149,6 +178,14 @@ describeIfDocker('Reverse Proxy Integration Tests', () => {
             timeout: DOCKER_TIMEOUT,
             env: dockerEnv,
         });
+
+        // Discover the ephemeral host ports Docker assigned.
+        NGINX_STRICT_PORT = getPublishedPort('nginx-strict', 443, dockerEnv);
+        NGINX_OPTIONAL_PORT = getPublishedPort('nginx-optional', 443, dockerEnv);
+        ENVOY_PORT = getPublishedPort('envoy', 443, dockerEnv);
+        ENVOY_CHAIN_ONLY_PORT = getPublishedPort('envoy-chain-only', 443, dockerEnv);
+        TRAEFIK_PORT = getPublishedPort('traefik', 443, dockerEnv);
+        console.log(`Discovered ports: nginx-strict=${NGINX_STRICT_PORT}, nginx-optional=${NGINX_OPTIONAL_PORT}, envoy=${ENVOY_PORT}, envoy-chain-only=${ENVOY_CHAIN_ONLY_PORT}, traefik=${TRAEFIK_PORT}`);
 
         // Wait for nginx-strict to be ready
         console.log('Waiting for nginx-strict to be ready...');
@@ -191,6 +228,20 @@ describeIfDocker('Reverse Proxy Integration Tests', () => {
             throw new Error('Envoy failed to start within timeout');
         }
         console.log('Envoy is ready!');
+
+        // Wait for Envoy chain-only to be ready
+        console.log('Waiting for Envoy (chain-only) to be ready...');
+        const envoyChainReady = await waitForService(
+            `https://localhost:${ENVOY_CHAIN_ONLY_PORT}/`,
+            certs.client.cert,
+            certs.client.key,
+            certs.ca.cert
+        );
+
+        if (!envoyChainReady) {
+            throw new Error('Envoy (chain-only) failed to start within timeout');
+        }
+        console.log('Envoy (chain-only) is ready!');
 
         // Wait for Traefik to be ready
         console.log('Waiting for Traefik to be ready...');
@@ -252,6 +303,23 @@ describeIfDocker('Reverse Proxy Integration Tests', () => {
 
             // nginx returns HTML error page
             expect(response).toContain('No required SSL certificate was sent');
+        });
+
+        it('should authenticate client signed via intermediate (chain)', async () => {
+            // Client presents [leaf, intermediate]. nginx walks chain to root,
+            // accepts, and forwards $ssl_client_escaped_cert which is leaf-only
+            // by spec (no chain variable exists in nginx).
+            const response = await makeRequest(
+                `https://localhost:${NGINX_STRICT_PORT}/`,
+                chainClientPresentedCert,
+                chainCerts.client.key,
+                certs.ca.cert
+            );
+
+            expect(response.success).toBe(true);
+            expect(response.clientCN).toBe('Test Chain Client');
+            // nginx forwards leaf only, so we have no chain to attach.
+            expect(response.issuerCertificateSubjectCN).toBeNull();
         });
 
         it('should reject request with untrusted certificate (nginx 400)', async () => {
@@ -387,6 +455,76 @@ describeIfDocker('Reverse Proxy Integration Tests', () => {
                 )
             ).rejects.toThrow();
         });
+
+        it('should authenticate client signed via intermediate (chain)', async () => {
+            // Client presents [leaf, intermediate]. Envoy validates against
+            // root and emits XFCC with both Cert= (leaf) and Chain= (full chain
+            // URL-encoded multi-block PEM, in field order Hash;Cert;Chain;Subject).
+            // Pre-fix: parseXfcc returns the first match (Cert), giving the leaf
+            // but no chain - issuerCertificate is undefined.
+            // Post-fix: parseXfcc prefers Chain when present and parses its
+            // multi-block PEM, preserving the chain via issuerCertificate.
+            const response = await makeRequest(
+                `https://localhost:${ENVOY_PORT}/`,
+                chainClientPresentedCert,
+                chainCerts.client.key,
+                certs.ca.cert
+            );
+
+            expect(response.success).toBe(true);
+            expect(response.clientCN).toBe('Test Chain Client');
+
+            // Diagnostic: confirm Envoy actually emitted a Chain field.
+            const xfcc = response.rawHeaderValue;
+            expect(xfcc).toMatch(/Chain="?[^;,]+/);
+
+            // Chain MUST be preserved: leaf's issuerCertificate should point
+            // to the intermediate cert.
+            expect(response.issuerCertificateSubjectCN).toBe('Test Intermediate CA');
+        });
+    });
+
+    // Tests with Envoy in chain-only XFCC config (Chain=, no Cert=).
+    // This config exposes parseXfcc's multi-block PEM handling - without a
+    // Cert= field to short-circuit on, the parser must process the Chain
+    // field correctly even when it contains multiple PEM blocks.
+    describe('Envoy chain-only (Chain= field, no Cert=)', () => {
+        it('should authenticate single-cert client (Chain has one block)', async () => {
+            const response = await makeRequest(
+                `https://localhost:${ENVOY_CHAIN_ONLY_PORT}/`,
+                certs.client.cert,
+                certs.client.key,
+                certs.ca.cert
+            );
+
+            expect(response.success).toBe(true);
+            expect(response.clientCN).toBe('Test Client');
+            // Confirm the XFCC has Chain= but no Cert= field
+            expect(response.rawHeaderValue).toMatch(/Chain="?[^;,]+/);
+            expect(response.rawHeaderValue).not.toMatch(/Cert=/);
+        });
+
+        it('should authenticate chain client (Chain has multi-block PEM)', async () => {
+            // Pre-fix: parseXfcc passes the multi-block Chain value to
+            // X509Certificate(pem). On Node 22+ that returns the leaf without
+            // throwing - but toLegacyObject() drops the issuerCertificate
+            // property, so the chain info is silently lost. Auth still works
+            // but req.clientCertificate.issuerCertificate is undefined.
+            // Post-fix: parseXfcc splits the multi-block Chain into individual
+            // blocks, parses each, links via issuerCertificate. Chain preserved.
+            const response = await makeRequest(
+                `https://localhost:${ENVOY_CHAIN_ONLY_PORT}/`,
+                chainClientPresentedCert,
+                chainCerts.client.key,
+                certs.ca.cert
+            );
+
+            expect(response.success).toBe(true);
+            expect(response.clientCN).toBe('Test Chain Client');
+            // The chain MUST be preserved: the leaf's issuerCertificate
+            // should point to the intermediate cert.
+            expect(response.issuerCertificateSubjectCN).toBe('Test Intermediate CA');
+        });
     });
 
     // Tests with Traefik proxy (uses PassTLSClientCert middleware)
@@ -423,6 +561,28 @@ describeIfDocker('Reverse Proxy Integration Tests', () => {
                     certs.ca.cert
                 )
             ).rejects.toThrow();
+        });
+
+        it('should authenticate client signed via intermediate (chain)', async () => {
+            // Client presents [leaf, intermediate]. Traefik validates against
+            // root, emits X-Forwarded-Tls-Client-Cert as comma-separated base64
+            // (delimiters stripped). parseBase64Der splits on comma and links
+            // the chain via issuerCertificate.
+            const response = await makeRequest(
+                `https://localhost:${TRAEFIK_PORT}/`,
+                chainClientPresentedCert,
+                chainCerts.client.key,
+                certs.ca.cert
+            );
+
+            expect(response.success).toBe(true);
+            expect(response.clientCN).toBe('Test Chain Client');
+
+            // Diagnostic: confirm Traefik forwarded a comma-separated chain.
+            expect(response.rawHeaderValue).toContain(',');
+
+            // Chain should be preserved by parseBase64Der.
+            expect(response.issuerCertificateSubjectCN).toBe('Test Intermediate CA');
         });
     });
 

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -115,8 +115,69 @@ export async function generateClientCertificate(commonName = 'Test Client', opti
 }
 
 /**
+ * Generate an intermediate CA + chain-signed client cert under an existing
+ * root CA. Used to extend an existing single-tier mTLS test setup with a
+ * 3-tier chain (root -> intermediate -> client) without disturbing the
+ * existing trust configuration.
+ *
+ * Chain shape:
+ *   rootCa (caller-supplied)
+ *     |- intermediate (CA, signed by rootCa)
+ *          |- client (leaf, signed by intermediate)
+ *
+ * The client should present [client.cert, intermediate.cert] (concatenated)
+ * to the TLS handshake so the proxy can walk the chain to the trusted root.
+ *
+ * @param {{cert: string, key: string}} rootCa - The existing root CA
+ * @param {Object} [options]
+ * @param {string} [options.intermediateCommonName='Test Intermediate CA']
+ * @param {string} [options.clientCommonName='Test Chain Client']
+ * @returns {Promise<{intermediate: {cert, key}, client: {cert, key}}>}
+ */
+export async function generateIntermediateChain(rootCa, options = {}) {
+    const {
+        intermediateCommonName = 'Test Intermediate CA',
+        clientCommonName = 'Test Chain Client',
+    } = options;
+
+    const intermediate = await selfsigned.generate(
+        [{ name: 'commonName', value: intermediateCommonName }],
+        {
+            algorithm: 'sha256',
+            keySize: 2048,
+            notBeforeDate: new Date(Date.now() - 60_000),
+            ca: { key: rootCa.key, cert: rootCa.cert },
+            extensions: [
+                { name: 'basicConstraints', cA: true, pathLenConstraint: 0, critical: true },
+                { name: 'keyUsage', keyCertSign: true, cRLSign: true, critical: true },
+            ],
+        }
+    );
+
+    const client = await selfsigned.generate(
+        [{ name: 'commonName', value: clientCommonName }],
+        {
+            algorithm: 'sha256',
+            keySize: 2048,
+            notBeforeDate: new Date(Date.now() - 60_000),
+            ca: { key: intermediate.private, cert: intermediate.cert },
+            extensions: [
+                { name: 'basicConstraints', cA: false, critical: true },
+                { name: 'keyUsage', digitalSignature: true, critical: true },
+                { name: 'extKeyUsage', clientAuth: true },
+            ],
+        }
+    );
+
+    return {
+        intermediate: { cert: intermediate.cert, key: intermediate.private },
+        client: { cert: client.cert, key: client.private },
+    };
+}
+
+/**
  * Convert PEM certificate to DER buffer.
- * 
+ *
  * @param {string} pem - PEM-encoded certificate
  * @returns {Buffer} DER-encoded certificate
  */

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -360,6 +360,73 @@ describe('parsers module', () => {
             assert.ok(cert, 'Should parse first element despite commas in quoted Subject');
             assert.equal(cert.subject.CN, 'Test Parser Client');
         });
+
+        it('should chain multi-block PEM in Chain field via issuerCertificate', async () => {
+            // Envoy with `chain: true` only emits Chain= as a single field
+            // containing the full chain as URL-encoded multi-block PEM. Pre-fix,
+            // pemToCertificate(multiBlockPem) returned the leaf without
+            // issuerCertificate (toLegacyObject drops it). Post-fix, parseXfcc
+            // splits the multi-block input and links via issuerCertificate.
+            const intermediateCert = await generateClientCertificate('Test Intermediate');
+            const multiBlock = testPem + intermediateCert.cert;
+            const xfcc = `Hash=abc;Chain="${encodeURIComponent(multiBlock)}"`;
+
+            const cert = parseXfcc(xfcc);
+            assert.ok(cert, 'Should parse multi-block Chain field');
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+            assert.ok(cert.issuerCertificate, 'Chain should be linked via issuerCertificate');
+            assert.equal(cert.issuerCertificate.subject.CN, 'Test Intermediate');
+        });
+
+        it('should prefer Chain over Cert when both fields are present', async () => {
+            // Envoy with both `cert: true` and `chain: true` emits Cert= (leaf)
+            // and Chain= (full chain). The Chain field carries strictly more
+            // information than Cert, so we prefer Chain.
+            const intermediateCert = await generateClientCertificate('Test Intermediate');
+            const multiBlock = testPem + intermediateCert.cert;
+            const xfcc = `Hash=abc;Cert="${encodeURIComponent(testPem)}";Chain="${encodeURIComponent(multiBlock)}"`;
+
+            const cert = parseXfcc(xfcc);
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+            // If we'd picked Cert (leaf-only), issuerCertificate would be undefined.
+            assert.ok(cert.issuerCertificate, 'Should pick Chain so chain info is preserved');
+            assert.equal(cert.issuerCertificate.subject.CN, 'Test Intermediate');
+        });
+
+        it('should drop a bad block in multi-block Chain and return the valid leaf', () => {
+            const invalidBlock = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64\n-----END CERTIFICATE-----\n';
+            const xfcc = `Hash=abc;Chain="${encodeURIComponent(testPem + invalidBlock)}"`;
+
+            const cert = parseXfcc(xfcc);
+            assert.ok(cert, 'Bad block dropped, valid leaf returned');
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+        });
+
+        it('should return null when every block in multi-block Chain is invalid', () => {
+            const invalidBlock1 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_1\n-----END CERTIFICATE-----\n';
+            const invalidBlock2 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_2\n-----END CERTIFICATE-----\n';
+            const xfcc = `Hash=abc;Chain="${encodeURIComponent(invalidBlock1 + invalidBlock2)}"`;
+
+            assert.equal(parseXfcc(xfcc), null);
+        });
+
+        it('should ignore an unterminated trailing PEM block in Chain', () => {
+            // Valid leaf followed by BEGIN with no END - scanner should stop
+            // there rather than hang or include junk in the leaf.
+            const truncated = '-----BEGIN CERTIFICATE-----\nMIIBkTCCATug==\n';
+            const xfcc = `Hash=abc;Chain="${encodeURIComponent(testPem + truncated)}"`;
+
+            const cert = parseXfcc(xfcc);
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+        });
+
+        it('should return null when Chain value has malformed URL encoding', () => {
+            // %G0 is not a valid percent-encoded sequence; decodeURIComponent
+            // throws URIError, which the outer try/catch turns into null.
+            assert.equal(parseXfcc('Hash=abc;Chain=%G0'), null);
+        });
     });
 
     describe('parseBase64Der (Cloudflare format)', () => {

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -384,13 +384,32 @@ describe('parsers module', () => {
             // information than Cert, so we prefer Chain.
             const intermediateCert = await generateClientCertificate('Test Intermediate');
             const multiBlock = testPem + intermediateCert.cert;
-            const xfcc = `Hash=abc;Cert="${encodeURIComponent(testPem)}";Chain="${encodeURIComponent(multiBlock)}"`;
+            // Cert appears AFTER Chain. This ordering matters: it ensures the
+            // parser routes each key to its own variable. If the parser routed
+            // both to the same variable (e.g. last-write-wins), the late Cert
+            // would overwrite Chain and we'd silently lose the chain info.
+            const xfcc = `Hash=abc;Chain="${encodeURIComponent(multiBlock)}";Cert="${encodeURIComponent(testPem)}"`;
 
             const cert = parseXfcc(xfcc);
             assert.ok(cert);
             assert.equal(cert.subject.CN, 'Test Parser Client');
             // If we'd picked Cert (leaf-only), issuerCertificate would be undefined.
             assert.ok(cert.issuerCertificate, 'Should pick Chain so chain info is preserved');
+            assert.equal(cert.issuerCertificate.subject.CN, 'Test Intermediate');
+        });
+
+        it('should still prefer Chain when Cert appears before Chain', async () => {
+            // Same prefer-Chain semantic, opposite key order. Pinning that the
+            // preference is not order-dependent (i.e. parser collects all keys
+            // first, then chooses, rather than first-or-last-match).
+            const intermediateCert = await generateClientCertificate('Test Intermediate');
+            const multiBlock = testPem + intermediateCert.cert;
+            const xfcc = `Hash=abc;Cert="${encodeURIComponent(testPem)}";Chain="${encodeURIComponent(multiBlock)}"`;
+
+            const cert = parseXfcc(xfcc);
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+            assert.ok(cert.issuerCertificate);
             assert.equal(cert.issuerCertificate.subject.CN, 'Test Intermediate');
         });
 
@@ -401,6 +420,25 @@ describe('parsers module', () => {
             const cert = parseXfcc(xfcc);
             assert.ok(cert, 'Bad block dropped, valid leaf returned');
             assert.equal(cert.subject.CN, 'Test Parser Client');
+        });
+
+        it('should drop a mid-chain bad block and chain around it cleanly', async () => {
+            // Three blocks: valid leaf, invalid intermediate, valid second cert.
+            // Without the .filter(Boolean), the leaf's issuerCertificate would
+            // get set to null instead of pointing past the bad block.
+            const intermediateCert = await generateClientCertificate('Test Intermediate');
+            const invalidBlock = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64\n-----END CERTIFICATE-----\n';
+            const blob = testPem + invalidBlock + intermediateCert.cert;
+            const xfcc = `Hash=abc;Chain="${encodeURIComponent(blob)}"`;
+
+            const cert = parseXfcc(xfcc);
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+            // Bad block was dropped, so the leaf's issuerCertificate should
+            // point to the intermediate cert (the next valid block) rather
+            // than null/undefined.
+            assert.ok(cert.issuerCertificate, 'leaf must chain to next valid cert, not null from dropped block');
+            assert.equal(cert.issuerCertificate.subject.CN, 'Test Intermediate');
         });
 
         it('should return null when every block in multi-block Chain is invalid', () => {


### PR DESCRIPTION
## Summary

`parseXfcc` previously returned the first matching `Cert=` or `Chain=` field without splitting multi-block PEM input. This silently lost chain information for `includeChain: true` consumers when Envoy was configured to forward the chain:

- **Cert+Chain config (typical)**: parser returned `Cert=` (leaf only), `issuerCertificate` undefined.
- **Chain-only config**: parser handed the multi-block PEM to `X509Certificate`, which on Node 22+ returns just the leaf and `toLegacyObject()` drops the `issuerCertificate` property. Same outcome: chain info lost.

Both paths now go through a shared `chainFromMultiBlockPem` helper (also used by `parseUrlPemAws`) that splits on `BEGIN CERTIFICATE` markers, parses each block, and links via `issuerCertificate`. When both `Cert` and `Chain` are present, parseXfcc prefers `Chain` (strictly more information per the Envoy spec).

## Empirical verification

Added a second Envoy listener to `docker-compose.yml` (`envoy-chain-only`) that emits XFCC with `Chain=` only (no `Cert=`), exposing the bug that the standard config shadows. Pre-fix, 2 chain tests fail (Envoy regular + Envoy chain-only). Post-fix, 26/26 E2E tests pass.

## Other changes in this PR

- `generateIntermediateChain()` test helper for 3-tier chain fixtures (root -> intermediate -> client).
- E2E suite uses ephemeral host ports for proxy services (Docker assigns, suite discovers via `docker compose port`). Avoids host-side port conflicts; some Windows services bind 8443/8444.
- nginx test config: `ssl_verify_depth 2` so it accepts chain-bearing clients.
- Test backend exposes `issuerCertificateSubjectCN` so chain tests can assert chain preservation.