### PR TITLE
fix(helpers): allOf() with zero callbacks fails closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`allOf()` zero-callback vacuous truth** — calling `allOf()` with no callbacks no longer silently authorizes all certificates. `[].every(...)` returns `true` in JavaScript (vacuous truth), so an empty composed policy reaching `allOf()` would authorize any certificate. Empty callback lists now return `() => false`, matching the v1.3.2 fix for `allowIssuer({})` and `allowSubject({})`. `anyOf()` was already safe because `[].some(...)` returns `false`.
+
+### Tests
+
+- Inverted the existing zero-callback pinning test for `allOf()` to assert fail-closed behavior.
+
 ## [1.3.3] - 2026-04-28
 
 ### Fixed

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -245,6 +245,9 @@ export function allowEmail(emails) {
  * )));
  */
 export function allOf(...callbacks) {
+    if (callbacks.length === 0) {
+        return () => false;
+    }
     return async (cert, req) => {
         const results = await Promise.all(callbacks.map((cb) => cb(cert, req)));
         return results.every((r) => r === true);

--- a/test/test-unit-helpers.js
+++ b/test/test-unit-helpers.js
@@ -659,9 +659,9 @@ describe('helpers', () => {
             assert.equal(await check(mockCert, mockReq), true);
         });
 
-        it('should return true with zero callbacks (vacuous truth)', async () => {
+        it('should return false with zero callbacks (fail closed)', async () => {
             const check = allOf();
-            assert.equal(await check(mockCert), true);
+            assert.equal(await check(mockCert), false);
         });
 
         it('should return false when callback returns truthy non-boolean value', async () => {


### PR DESCRIPTION
## Summary

- `allOf()` called with no callbacks returned a validator that authorized every certificate (`[].every(...)` is vacuously true). Now returns `() => false`.
- Same vacuous-truth class of bug as the v1.3.2 fix for `allowIssuer({})` and `allowSubject({})`; same fix shape.
- `anyOf()` was already safe (`[].some(...)` is `false`); no change there.
- Existing zero-callback test had pinned the broken behavior; inverted to assert fail-closed.

## Test plan

- [ ] `npm test` passes (full unit + integration suite).
- [ ] Coverage remains 100%.
- [ ] Inverted test reads correctly: `should return false with zero callbacks (fail closed)`.
- [ ] No production caller anywhere in the repo composes `allOf()` with zero arguments (verified locally with grep; only the test file did).
- [ ] CHANGELOG `[Unreleased]` entry reads accurately for the next release tag.