### PR TITLE
chore: declare eslint config dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@commitlint/cli": "^20.4.3",
         "@commitlint/config-conventional": "^20.5.0",
+        "@eslint/js": "^9.39.4",
         "@stryker-mutator/core": "^9.6.0",
         "@stryker-mutator/jest-runner": "^9.6.1",
         "@types/express": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.5.0",
+    "@eslint/js": "^9.39.4",
     "@stryker-mutator/core": "^9.6.0",
     "@stryker-mutator/jest-runner": "^9.6.1",
     "@types/express": "^5.0.6",


### PR DESCRIPTION
fixes dependabot not managing to bump to eslint 10