### PR TITLE
fix(auth)!: require strict true from validation callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed (BREAKING)
+
+- **Validation callbacks must return or resolve exactly `true`** — previously the middleware authorized on any truthy value, so callbacks returning a non-empty string, a number, an object, or a thenable resolving to a truthy non-boolean would silently pass authentication. Both the ESM and CJS paths now require strict `=== true`; all other values (including non-`true` truthy values and `Promise<truthy-non-boolean>`) cause a 401. The fix also closes a fail-open with non-native thenables: `instanceof Promise` is replaced with a duck-typed `isThenable` check, so `{ then(resolve) { resolve(false); } }` correctly rejects rather than being passed through as a truthy object. Migration: callbacks that previously returned ad-hoc truthy values (e.g., `return cert.subject.CN`) must now explicitly return `true`/`false`. The helper composition functions in `lib/helpers.js` (`allOf`, `anyOf`) already enforced strict-true, so middleware behavior is now consistent with helpers.
+
+### Tests
+
+- Inverted the three truthy-non-boolean tests in `test-unit-clientCertificateAuth.js` to assert 401 rejection.
+- Added thenable coverage for both ESM and CJS: a non-native thenable resolving to `true` authorizes, resolving to `false` rejects, resolving to a truthy non-boolean rejects.
+
 ## [1.3.4] - 2026-04-30
 
 ### Fixed

--- a/lib/clientCertificateAuth.cjs
+++ b/lib/clientCertificateAuth.cjs
@@ -20,6 +20,16 @@ async function loadModule() {
 }
 
 /**
+ * Duck-typed thenable check: matches any object with a callable `.then`,
+ * so non-native thenables get awaited like native Promises.
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isThenable(value) {
+    return value !== null && typeof value === 'object' && typeof value.then === 'function';
+}
+
+/**
  * Options not supported by the sync CJS wrapper.
  * These require the ESM module's async header parsing.
  */
@@ -106,7 +116,7 @@ function clientCertificateAuth(callback, options = {}) {
         req.clientCertificate = cert;
 
         function doneAuthorizing(authorized) {
-            if (authorized) {
+            if (authorized === true) {
                 safeCallHook(onAuthenticated, cert, req);
                 return next();
             } else {
@@ -119,8 +129,8 @@ function clientCertificateAuth(callback, options = {}) {
 
         try {
             const result = callback(cert, req);
-            if (result instanceof Promise) {
-                result.then(doneAuthorizing).catch((err) => {
+            if (isThenable(result)) {
+                Promise.resolve(result).then(doneAuthorizing).catch((err) => {
                     safeCallHook(onRejected, cert, req, err.message || 'callback_threw');
                     if (err.status === undefined) {
                         err.status = 401;

--- a/lib/clientCertificateAuth.cjs
+++ b/lib/clientCertificateAuth.cjs
@@ -20,13 +20,16 @@ async function loadModule() {
 }
 
 /**
- * Duck-typed thenable check: matches any object with a callable `.then`,
- * so non-native thenables get awaited like native Promises.
+ * Duck-typed thenable check per Promises/A+: an object or function with
+ * a callable `.then` method. Matches the set of values `Promise.resolve`
+ * natively adopts as thenables.
  * @param {unknown} value
  * @returns {boolean}
  */
 function isThenable(value) {
-    return value !== null && typeof value === 'object' && typeof value.then === 'function';
+    return value !== null
+        && (typeof value === 'object' || typeof value === 'function')
+        && typeof value.then === 'function';
 }
 
 /**

--- a/lib/clientCertificateAuth.d.cts
+++ b/lib/clientCertificateAuth.d.cts
@@ -94,7 +94,7 @@ export interface ClientCertificateAuthOptions {
 export type ValidationCallback = (
     cert: PeerCertificate | DetailedPeerCertificate,
     req?: ClientCertRequest
-) => boolean | Promise<boolean>;
+) => boolean | PromiseLike<boolean>;
 
 export type Middleware = (
     req: ClientCertRequest,

--- a/lib/clientCertificateAuth.d.ts
+++ b/lib/clientCertificateAuth.d.ts
@@ -123,7 +123,7 @@ export interface ClientCertificateAuthOptions {
 export type ValidationCallback = (
     cert: PeerCertificate | DetailedPeerCertificate,
     req?: ClientCertRequest
-) => boolean | Promise<boolean>;
+) => boolean | PromiseLike<boolean>;
 
 export type Middleware = (
     req: ClientCertRequest,
@@ -135,7 +135,8 @@ export type Middleware = (
  * Express/Connect middleware for client SSL certificate authentication.
  *
  * @param callback - Validation function that receives the client certificate
- *   and returns true/false (sync) or `Promise<boolean>` (async).
+ *   and returns true/false (sync) or `PromiseLike<boolean>` (async,
+ *   including native Promises and any thenable resolving to a boolean).
  * @param options - Configuration options
  * @returns Express middleware function
  *

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -8,6 +8,16 @@
 import { extractClientCertificate } from './extractor.js';
 
 /**
+ * Duck-typed thenable check: matches any object with a callable `.then`,
+ * so non-native thenables get awaited like native Promises.
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isThenable(value) {
+  return value !== null && typeof value === 'object' && typeof /** @type {{then?: unknown}} */ (value).then === 'function';
+}
+
+/**
  * @typedef {import('http').IncomingMessage & { secure?: boolean; socket: import('tls').TLSSocket & { authorized?: boolean; authorizationError?: string }; clientCertificate?: import('tls').PeerCertificate }} ClientCertRequest
  * @typedef {import('http').ServerResponse & { redirect: (statusOrUrl: number | string, url?: string) => void }} ClientCertResponse
  * @typedef {(req: ClientCertRequest, res: ClientCertResponse, next: (err?: Error) => void) => void} Middleware
@@ -165,10 +175,10 @@ export default function clientCertificateAuth(callback, options = {}) {
     req.clientCertificate = cert;
 
     /**
-     * @param {boolean} authorized
+     * @param {unknown} authorized
      */
     function doneAuthorizing(authorized) {
-      if (authorized) {
+      if (authorized === true) {
         safeCallHook(onAuthenticated, cert, req);
         return next();
       } else {
@@ -181,8 +191,8 @@ export default function clientCertificateAuth(callback, options = {}) {
 
     try {
       const callbackResult = callback(cert, req);
-      if (callbackResult instanceof Promise) {
-        callbackResult.then(doneAuthorizing).catch((err) => {
+      if (isThenable(callbackResult)) {
+        Promise.resolve(callbackResult).then(doneAuthorizing).catch((err) => {
           safeCallHook(onRejected, cert, req, err.message || 'callback_threw');
           if (err.status === undefined) {
             err.status = 401;

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -57,12 +57,13 @@ function isThenable(value) {
  * passed the client certificate information for additional validation.
  *
  * The callback receives the certificate (as obtained through
- * `req.socket.getPeerCertificate()` or extracted from headers) and must 
- * return `true` (or a Promise resolving to `true`) for the request to proceed.
+ * `req.socket.getPeerCertificate()` or extracted from headers) and must
+ * return `true` (or a thenable resolving to `true`) for the request to proceed.
  *
- * @param {(cert: import('tls').PeerCertificate, req: ClientCertRequest) => boolean | Promise<boolean>} callback
+ * @param {(cert: import('tls').PeerCertificate, req: ClientCertRequest) => boolean | PromiseLike<boolean>} callback
  *   Validation function that receives the client certificate and the request
- *   object. Returns true/false (sync) or a `Promise<boolean>` (async) to
+ *   object. Returns true/false (sync) or a `PromiseLike<boolean>` (async,
+ *   including native Promises and any thenable resolving to a boolean) to
  *   allow/deny access.
  * @param {ClientCertificateAuthOptions} [options={}]
  * @returns {Middleware}

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -8,13 +8,16 @@
 import { extractClientCertificate } from './extractor.js';
 
 /**
- * Duck-typed thenable check: matches any object with a callable `.then`,
- * so non-native thenables get awaited like native Promises.
+ * Duck-typed thenable check per Promises/A+: an object or function with
+ * a callable `.then` method. Matches the set of values `Promise.resolve`
+ * natively adopts as thenables.
  * @param {unknown} value
  * @returns {boolean}
  */
 function isThenable(value) {
-  return value !== null && typeof value === 'object' && typeof /** @type {{then?: unknown}} */ (value).then === 'function';
+  return value !== null
+    && (typeof value === 'object' || typeof value === 'function')
+    && typeof /** @type {{then?: unknown}} */ (value).then === 'function';
 }
 
 /**

--- a/test/test-typescript-types.ts
+++ b/test/test-typescript-types.ts
@@ -3,7 +3,7 @@
  * This file is not executed, only type-checked by `npm run typecheck`.
  */
 import clientCertificateAuth from '../lib/clientCertificateAuth.js';
-import type { ClientCertRequest, HttpError, ClientCertificateAuthOptions } from '../lib/clientCertificateAuth.js';
+import type { ClientCertRequest, HttpError, ClientCertificateAuthOptions, ValidationCallback } from '../lib/clientCertificateAuth.js';
 
 // Test 1: Error.status augmentation works on plain Error objects
 const plainError = new Error('test');
@@ -50,6 +50,19 @@ const _reqMiddleware = clientCertificateAuth((cert, req) => {
     }
     return cert.subject.CN === 'admin';
 });
+
+// Test 7a: callback may return a PromiseLike<boolean> (any thenable, not just native Promise)
+const _promiseLikeCallback: ValidationCallback = (cert) => {
+    const thenable: PromiseLike<boolean> = {
+        then(onfulfilled) {
+            return onfulfilled
+                ? (onfulfilled(cert.subject.CN === 'admin') as PromiseLike<never>)
+                : (undefined as unknown as PromiseLike<never>);
+        },
+    };
+    return thenable;
+};
+const _promiseLikeMiddleware = clientCertificateAuth(_promiseLikeCallback);
 
 // Test 8: CJS load() returns function with full ESM options
 import type cjsAuth from '../lib/clientCertificateAuth.cjs';

--- a/test/test-unit-clientCertificateAuth.cjs
+++ b/test/test-unit-clientCertificateAuth.cjs
@@ -152,6 +152,43 @@ describe('clientCertificateAuth (CommonJS)', () => {
                 }
             );
 
+            it('should pass 401 error to next() if callback returns a truthy non-boolean value', done => {
+                const middleware = clientCertificateAuth(() => 'yes');
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.status, 401);
+                    assert.equal(err.message, 'Unauthorized');
+                    done();
+                });
+            });
+
+            it('should pass 401 error to next() if async callback resolves with a truthy non-boolean', done => {
+                const middleware = clientCertificateAuth(async () => 'yes');
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.status, 401);
+                    done();
+                });
+            });
+
+            it('should call next() if callback returns a non-native thenable resolving to true', done => {
+                const middleware = clientCertificateAuth(() => ({ then(resolve) { resolve(true); } }));
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.equal(err, undefined);
+                    done();
+                });
+            });
+
+            it('should pass 401 error to next() if callback returns a non-native thenable resolving to false', done => {
+                const middleware = clientCertificateAuth(() => ({ then(resolve) { resolve(false); } }));
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.status, 401);
+                    assert.equal(err.message, 'Unauthorized');
+                    done();
+                });
+            });
+
             it('should pass error to next() if callback throws', done => {
                 const middleware = clientCertificateAuth(() => {
                     throw new Error('Validation failed');

--- a/test/test-unit-clientCertificateAuth.cjs
+++ b/test/test-unit-clientCertificateAuth.cjs
@@ -189,6 +189,32 @@ describe('clientCertificateAuth (CommonJS)', () => {
                 });
             });
 
+            it('should call next() if callback returns a function-valued thenable resolving to true', done => {
+                const middleware = clientCertificateAuth(() => {
+                    const fn = function () {};
+                    fn.then = (resolve) => resolve(true);
+                    return fn;
+                });
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.equal(err, undefined);
+                    done();
+                });
+            });
+
+            it('should pass 401 error to next() if callback returns a function-valued thenable resolving to false', done => {
+                const middleware = clientCertificateAuth(() => {
+                    const fn = function () {};
+                    fn.then = (resolve) => resolve(false);
+                    return fn;
+                });
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.status, 401);
+                    assert.equal(err.message, 'Unauthorized');
+                    done();
+                });
+            });
+
             it('should pass error to next() if callback throws', done => {
                 const middleware = clientCertificateAuth(() => {
                     throw new Error('Validation failed');

--- a/test/test-unit-clientCertificateAuth.js
+++ b/test/test-unit-clientCertificateAuth.js
@@ -113,26 +113,59 @@ describe('clientCertificateAuth', () => {
         }
       );
 
-      it('should call next() if callback returns a truthy non-boolean value (string)', done => {
+      it('should pass 401 error to next() if callback returns a truthy non-boolean value (string)', done => {
         const middleware = clientCertificateAuth(() => 'yes');
         middleware(mockGoodReq, mockRes, (err) => {
-          assert.equal(err, undefined);
+          assert.ok(err instanceof Error);
+          assert.equal(err.status, 401);
+          assert.equal(err.message, 'Unauthorized');
           done();
         });
       });
 
-      it('should call next() if callback returns a truthy non-boolean value (number)', done => {
+      it('should pass 401 error to next() if callback returns a truthy non-boolean value (number)', done => {
         const middleware = clientCertificateAuth(() => 1);
         middleware(mockGoodReq, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.status, 401);
+          assert.equal(err.message, 'Unauthorized');
+          done();
+        });
+      });
+
+      it('should pass 401 error to next() if async callback resolves with a truthy non-boolean value', done => {
+        const middleware = clientCertificateAuth(async () => 'authorized');
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.status, 401);
+          assert.equal(err.message, 'Unauthorized');
+          done();
+        });
+      });
+
+      it('should call next() if callback returns a non-native thenable resolving to true', done => {
+        const middleware = clientCertificateAuth(() => ({ then(resolve) { resolve(true); } }));
+        middleware(mockGoodReq, mockRes, (err) => {
           assert.equal(err, undefined);
           done();
         });
       });
 
-      it('should call next() if async callback resolves with a truthy non-boolean value', done => {
-        const middleware = clientCertificateAuth(async () => 'authorized');
+      it('should pass 401 error to next() if callback returns a non-native thenable resolving to false', done => {
+        const middleware = clientCertificateAuth(() => ({ then(resolve) { resolve(false); } }));
         middleware(mockGoodReq, mockRes, (err) => {
-          assert.equal(err, undefined);
+          assert.ok(err instanceof Error);
+          assert.equal(err.status, 401);
+          assert.equal(err.message, 'Unauthorized');
+          done();
+        });
+      });
+
+      it('should pass 401 error to next() if callback returns a non-native thenable resolving to a truthy non-boolean', done => {
+        const middleware = clientCertificateAuth(() => ({ then(resolve) { resolve('yes'); } }));
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.status, 401);
           done();
         });
       });

--- a/test/test-unit-clientCertificateAuth.js
+++ b/test/test-unit-clientCertificateAuth.js
@@ -170,6 +170,31 @@ describe('clientCertificateAuth', () => {
         });
       });
 
+      it('should call next() if callback returns a function-valued thenable resolving to true', done => {
+        const middleware = clientCertificateAuth(() => {
+          const fn = function () {};
+          fn.then = (resolve) => resolve(true);
+          return fn;
+        });
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.equal(err, undefined);
+          done();
+        });
+      });
+
+      it('should pass 401 error to next() if callback returns a function-valued thenable resolving to false', done => {
+        const middleware = clientCertificateAuth(() => {
+          const fn = function () {};
+          fn.then = (resolve) => resolve(false);
+          return fn;
+        });
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.status, 401);
+          done();
+        });
+      });
+
       it(
         'should pass 401 error to next() if callback returns false',
         done => {


### PR DESCRIPTION
Tightens the middleware's authorization check from truthy to strict `=== true` and widens Promise detection to duck-typed thenables. Closes two fail-open paths in a security middleware:

1. **Truthy-non-boolean callback returns authorized.** A callback returning `'yes'`, `1`, an object, or any truthy non-boolean would silently pass authentication. Now only `true` authorizes; everything else (including thenables that resolve to truthy non-booleans) returns 401.
2. **Non-native thenables slipped past `instanceof Promise`.** `{ then(resolve) { resolve(false); } }` was treated as a truthy object and authorized. Replaced with a duck-typed `isThenable` check so non-native thenables get awaited like native Promises.

Both the ESM (`lib/clientCertificateAuth.js`) and CJS (`lib/clientCertificateAuth.cjs`) paths now use the same strict semantics.

This also closes a behavior gap with the helper composition functions: `lib/helpers.js` `allOf` and `anyOf` already enforced strict-true (see existing tests `test-unit-helpers.js:667,717`), so middleware behavior is now consistent with helpers.

### BREAKING CHANGE

Validation callbacks that previously relied on truthy semantics must now explicitly return `true`/`false`. Examples that previously authorized but now reject:

```js
// Before: authorized (truthy string). After: 401.
clientCertificateAuth((cert) => cert.subject.CN)

// Before: authorized (truthy number). After: 401.
clientCertificateAuth((cert) => 1)

// Before: authorized (truthy object). After: 401.
clientCertificateAuth(async (cert) => ({ ok: true }))
```