### PR TITLE
feat(config): validate header options at construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Validation callbacks must return or resolve exactly `true`** — previously the middleware authorized on any truthy value, so callbacks returning a non-empty string, a number, an object, or a thenable resolving to a truthy non-boolean would silently pass authentication. Both the ESM and CJS paths now require strict `=== true`; all other values (including non-`true` truthy values and `Promise<truthy-non-boolean>`) cause a 401. The fix also closes a fail-open with non-native thenables: `instanceof Promise` is replaced with a duck-typed `isThenable` check, so `{ then(resolve) { resolve(false); } }` correctly rejects rather than being passed through as a truthy object. Migration: callbacks that previously returned ad-hoc truthy values (e.g., `return cert.subject.CN`) must now explicitly return `true`/`false`. The helper composition functions in `lib/helpers.js` (`allOf`, `anyOf`) already enforced strict-true, so middleware behavior is now consistent with helpers.
 
+### Added
+
+- **Constructor-time validation of header options** — `clientCertificateAuth()` now throws at construction when `certificateSource` is not a known preset, when `headerEncoding` is not a documented value, or when `certificateHeader` is set without `headerEncoding` (and no `certificateSource` preset to supply one). Mirrors the existing `verifyHeader`/`verifyValue` pairing check. Typos that previously caused silent header-extraction failure (falling through to socket extraction when `fallbackToSocket: true`, or returning 401 otherwise) now surface as a clear error at app startup.
+
 ### Tests
 
 - Inverted the three truthy-non-boolean tests in `test-unit-clientCertificateAuth.js` to assert 401 rejection.
 - Added thenable coverage for both ESM and CJS: a non-native thenable resolving to `true` authorizes, resolving to `false` rejects, resolving to a truthy non-boolean rejects.
+- Added a `constructor option validation` describe block covering unknown `certificateSource`, unknown `headerEncoding`, and `certificateHeader` without an encoding source.
 
 ## [1.3.4] - 2026-04-30
 

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -111,7 +111,7 @@ export default function clientCertificateAuth(callback, options = {}) {
     );
   }
 
-  if (certificateSource && !(certificateSource in PRESETS)) {
+  if (certificateSource && !Object.hasOwn(PRESETS, certificateSource)) {
     throw new Error(
       `client-certificate-auth: unknown certificateSource '${certificateSource}'. Valid values: ${Object.keys(PRESETS).join(', ')}`
     );

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -6,6 +6,9 @@
  */
 
 import { extractClientCertificate } from './extractor.js';
+import { PRESETS } from './parsers.js';
+
+const VALID_ENCODINGS = ['url-pem', 'url-pem-aws', 'xfcc', 'base64-der', 'rfc9440'];
 
 /**
  * Duck-typed thenable check per Promises/A+: an object or function with
@@ -105,6 +108,24 @@ export default function clientCertificateAuth(callback, options = {}) {
   if ((verifyHeader && !verifyValue) || (!verifyHeader && verifyValue)) {
     throw new Error(
       'client-certificate-auth: verifyHeader and verifyValue must both be provided together, or both omitted'
+    );
+  }
+
+  if (certificateSource && !(certificateSource in PRESETS)) {
+    throw new Error(
+      `client-certificate-auth: unknown certificateSource '${certificateSource}'. Valid values: ${Object.keys(PRESETS).join(', ')}`
+    );
+  }
+
+  if (headerEncoding && !VALID_ENCODINGS.includes(headerEncoding)) {
+    throw new Error(
+      `client-certificate-auth: unknown headerEncoding '${headerEncoding}'. Valid values: ${VALID_ENCODINGS.join(', ')}`
+    );
+  }
+
+  if (certificateHeader && !certificateSource && !headerEncoding) {
+    throw new Error(
+      'client-certificate-auth: certificateHeader requires headerEncoding (or a certificateSource preset that supplies one)'
     );
   }
 

--- a/test/test-unit-clientCertificateAuth.js
+++ b/test/test-unit-clientCertificateAuth.js
@@ -722,6 +722,60 @@ describe('clientCertificateAuth', () => {
       });
     });
 
+    describe('constructor option validation', () => {
+      it('should throw when certificateSource is unknown', () => {
+        assert.throws(
+          () => clientCertificateAuth(() => true, { certificateSource: 'aws-alp' }),
+          {
+            name: 'Error',
+            message: /unknown certificateSource 'aws-alp'/
+          }
+        );
+      });
+
+      it('should throw when headerEncoding is unknown', () => {
+        assert.throws(
+          () => clientCertificateAuth(() => true, {
+            certificateHeader: 'X-Cert',
+            headerEncoding: 'url-perm'
+          }),
+          {
+            name: 'Error',
+            message: /unknown headerEncoding 'url-perm'/
+          }
+        );
+      });
+
+      it('should throw when certificateHeader is set without headerEncoding or preset', () => {
+        assert.throws(
+          () => clientCertificateAuth(() => true, { certificateHeader: 'X-Cert' }),
+          {
+            name: 'Error',
+            message: /certificateHeader requires headerEncoding/
+          }
+        );
+      });
+
+      it('should not throw when certificateHeader pairs with a preset (encoding from preset)', () => {
+        assert.doesNotThrow(
+          () => clientCertificateAuth(() => true, {
+            certificateSource: 'aws-alb',
+            certificateHeader: 'X-Override'
+          })
+        );
+      });
+
+      it('should not throw when certificateSource alone is valid', () => {
+        assert.doesNotThrow(
+          () => clientCertificateAuth(() => true, { certificateSource: 'envoy' })
+        );
+      });
+
+      it('should not throw when no header options are set (socket-only)', () => {
+        assert.doesNotThrow(() => clientCertificateAuth(() => true));
+      });
+    });
+
     describe('error message content', () => {
       it('should include "unknown" when authorizationError is missing', done => {
         const reqNoError = {

--- a/test/test-unit-clientCertificateAuth.js
+++ b/test/test-unit-clientCertificateAuth.js
@@ -733,6 +733,19 @@ describe('clientCertificateAuth', () => {
         );
       });
 
+      it('should throw when certificateSource is an inherited Object.prototype key', () => {
+        for (const key of ['toString', 'constructor', 'hasOwnProperty', '__proto__']) {
+          assert.throws(
+            () => clientCertificateAuth(() => true, { certificateSource: key }),
+            {
+              name: 'Error',
+              message: new RegExp(`unknown certificateSource '${key}'`)
+            },
+            `${key} should be rejected as an inherited prototype key`
+          );
+        }
+      });
+
       it('should throw when headerEncoding is unknown', () => {
         assert.throws(
           () => clientCertificateAuth(() => true, {


### PR DESCRIPTION
Surfaces three classes of misconfiguration at app startup that previously failed silently at request time:

1. **Unknown `certificateSource` preset** (e.g. `'aws-alp'` instead of `'aws-alb'`) — `getCertificateFromHeaders` would return null, and with `fallbackToSocket: true` the request silently routed to socket-based extraction. Now throws with a message naming the bad value and listing the valid presets.
2. **Unknown `headerEncoding`** (e.g. `'url-perm'` instead of `'url-pem'`) — same silent-null failure mode. Now throws naming the bad value and valid encodings.
3. **`certificateHeader` without `headerEncoding` or `certificateSource`** — the header was looked up but no decoder was registered, so it always returned null. Now throws explaining that a custom header requires an explicit encoding or a preset to supply one.

Mirrors the existing `verifyHeader`/`verifyValue` pairing check at `lib/clientCertificateAuth.js:101-105`. The CJS sync wrapper already rejects all header-extraction options outright, so it needs no change.