### PR TITLE
chore(deps): bump client-certificate-auth from 1.3.4 to 2.0.0 in /examples/e2e-mtls

### DIFF
--- a/examples/e2e-mtls/package-lock.json
+++ b/examples/e2e-mtls/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "e2e-mtls-example",
       "dependencies": {
-        "client-certificate-auth": "^1.3.0",
+        "client-certificate-auth": "^2.0.0",
         "express": "^5.2.1"
       }
     },
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/client-certificate-auth": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/client-certificate-auth/-/client-certificate-auth-1.3.4.tgz",
-      "integrity": "sha512-Y15R3Sr1BKax98WcY4LpSNeZ5PUZShj54rex1j2Nf+lI2Yot4GEkr2pfVP/QeBGb9+jSnbZvdPWewvvNk0VBtQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/client-certificate-auth/-/client-certificate-auth-2.0.0.tgz",
+      "integrity": "sha512-xOyp+oyAV7dYGBdKcn+V0NdTbFda3x/Hi+oorUh93laLt9mvE/HAleHp1KOZmqdX6rlZANPByQ3MiI0l8r+3vw==",
       "license": "MIT",
       "engines": {
         "node": ">= 20"

--- a/examples/e2e-mtls/package.json
+++ b/examples/e2e-mtls/package.json
@@ -9,7 +9,7 @@
     "test": "node test-client.js"
   },
   "dependencies": {
-    "client-certificate-auth": "^1.3.0",
+    "client-certificate-auth": "^2.0.0",
     "express": "^5.2.1"
   }
 }


### PR DESCRIPTION
Bumps the example to the just-published v2.0.0.