### PR TITLE
fix: Express TS compat + align CJS runtime with widened socket type

### DIFF
--- a/docs/guide/typescript.md
+++ b/docs/guide/typescript.md
@@ -26,7 +26,7 @@ app.use(clientCertificateAuth(checkAuth, {
 }));
 ```
 
-The `ClientCertRequest` type extends Express's `Request` with the `clientCertificate` property. Use it in downstream route handlers to get type-safe access to the attached certificate.
+The `ClientCertRequest` type extends Node's `http.IncomingMessage` and is structurally compatible with Express's `Request` and other Connect-style request types. It adds the optional `clientCertificate` property the middleware attaches after authentication. Use it in downstream route handlers to get type-safe access to the attached certificate. The package does not depend on `@types/express`, so consumers using bare Node or non-Express Connect-style frameworks can use these types without pulling in Express's types.
 
 For complete type definitions, see the [API reference](/api/clientCertificateAuth/).
 

--- a/lib/clientCertificateAuth.cjs
+++ b/lib/clientCertificateAuth.cjs
@@ -104,6 +104,18 @@ function clientCertificateAuth(callback, options = {}) {
             return next(e);
         }
 
+        // Socket may report authorized: true without exposing TLS methods (mocks,
+        // misconfigured non-TLS path that nonetheless sets authorized). Mirrors the
+        // guard in the ESM extractor (lib/extractor.js).
+        if (typeof req.socket.getPeerCertificate !== 'function') {
+            safeCallHook(onRejected, null, req, 'certificate_not_retrievable');
+            const e = new Error(
+                'Client certificate was authenticated but certificate information could not be retrieved.'
+            );
+            e.status = 500;
+            return next(e);
+        }
+
         // Obtain certificate details
         const cert = req.socket.getPeerCertificate(includeChain);
         if (!cert || Object.keys(cert).length === 0) {

--- a/lib/clientCertificateAuth.d.cts
+++ b/lib/clientCertificateAuth.d.cts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'http';
-import type { TLSSocket, PeerCertificate, DetailedPeerCertificate } from 'tls';
+import type { Socket } from 'net';
+import type { PeerCertificate, DetailedPeerCertificate } from 'tls';
 import type {
     ClientCertificateAuthOptions as EsmOptions,
     ValidationCallback as EsmValidationCallback,
@@ -24,17 +25,31 @@ export interface HttpError extends Error {
 }
 
 /**
- * Extended request object with TLS socket and optional Express properties.
+ * Extended request object compatible with Node's `http.IncomingMessage`,
+ * Express's `Request`, and Connect-style request objects.
+ *
+ * The socket is typed as the broader `net.Socket` with TLS-specific fields
+ * marked optional so the middleware accepts requests from any of those
+ * frameworks without a framework-specific type dependency. The runtime
+ * guards in the middleware check for `getPeerCertificate` before calling it.
  */
 export interface ClientCertRequest extends IncomingMessage {
-    /** True if connection is over HTTPS (Express-specific) */
+    /** True if connection is over HTTPS (Express-specific, optional). */
     secure?: boolean;
-    /** TLS socket with authorization properties */
-    socket: TLSSocket & {
-        /** Whether the client certificate was authorized at the TLS layer */
+    /**
+     * Underlying socket. Typed as the broader `net.Socket` so this interface
+     * is satisfied by both Node's `IncomingMessage.socket` and Express's
+     * `Request.socket`. TLS-specific fields (`authorized`, `authorizationError`,
+     * `getPeerCertificate`) are present at runtime when the request arrived
+     * over TLS and are detected by the middleware via runtime feature checks.
+     */
+    socket: Socket & {
+        /** Whether the client certificate was authorized at the TLS layer. */
         authorized?: boolean;
-        /** Error message if authorization failed */
-        authorizationError?: string;
+        /** Error from TLS authorization, if any. */
+        authorizationError?: Error | string;
+        /** TLS getPeerCertificate, present on TLSSocket only. */
+        getPeerCertificate?: (detailed?: boolean) => PeerCertificate | DetailedPeerCertificate;
     };
     /**
      * Client certificate attached by clientCertificateAuth middleware.

--- a/lib/clientCertificateAuth.d.ts
+++ b/lib/clientCertificateAuth.d.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'http';
-import type { TLSSocket, PeerCertificate, DetailedPeerCertificate } from 'tls';
+import type { Socket } from 'net';
+import type { PeerCertificate, DetailedPeerCertificate } from 'tls';
 import type { CertificateSource, HeaderEncoding } from './parsers.js';
 
 export type { CertificateSource, HeaderEncoding };
@@ -22,17 +23,31 @@ export interface HttpError extends Error {
 }
 
 /**
- * Extended request object with TLS socket and optional Express properties.
+ * Extended request object compatible with Node's `http.IncomingMessage`,
+ * Express's `Request`, and Connect-style request objects.
+ *
+ * The socket is typed as the broader `net.Socket` with TLS-specific fields
+ * marked optional so the middleware accepts requests from any of those
+ * frameworks without a framework-specific type dependency. The runtime
+ * guards in the middleware check for `getPeerCertificate` before calling it.
  */
 export interface ClientCertRequest extends IncomingMessage {
-    /** True if connection is over HTTPS (Express-specific) */
+    /** True if connection is over HTTPS (Express-specific, optional). */
     secure?: boolean;
-    /** TLS socket with authorization properties */
-    socket: TLSSocket & {
-        /** Whether the client certificate was authorized at the TLS layer */
+    /**
+     * Underlying socket. Typed as the broader `net.Socket` so this interface
+     * is satisfied by both Node's `IncomingMessage.socket` and Express's
+     * `Request.socket`. TLS-specific fields (`authorized`, `authorizationError`,
+     * `getPeerCertificate`) are present at runtime when the request arrived
+     * over TLS and are detected by the middleware via runtime feature checks.
+     */
+    socket: Socket & {
+        /** Whether the client certificate was authorized at the TLS layer. */
         authorized?: boolean;
-        /** Error message if authorization failed */
-        authorizationError?: string;
+        /** Error from TLS authorization, if any. */
+        authorizationError?: Error | string;
+        /** TLS getPeerCertificate, present on TLSSocket only. */
+        getPeerCertificate?: (detailed?: boolean) => PeerCertificate | DetailedPeerCertificate;
     };
     /**
      * Client certificate attached by clientCertificateAuth middleware.

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -24,7 +24,7 @@ function isThenable(value) {
 }
 
 /**
- * @typedef {import('http').IncomingMessage & { secure?: boolean; socket: import('tls').TLSSocket & { authorized?: boolean; authorizationError?: string }; clientCertificate?: import('tls').PeerCertificate }} ClientCertRequest
+ * @typedef {import('http').IncomingMessage & { secure?: boolean; socket: import('net').Socket & { authorized?: boolean; authorizationError?: Error | string; getPeerCertificate?: (detailed?: boolean) => import('tls').PeerCertificate | import('tls').DetailedPeerCertificate }; clientCertificate?: import('tls').PeerCertificate }} ClientCertRequest
  * @typedef {import('http').ServerResponse & { redirect: (statusOrUrl: number | string, url?: string) => void }} ClientCertResponse
  * @typedef {(req: ClientCertRequest, res: ClientCertResponse, next: (err?: Error) => void) => void} Middleware
  */

--- a/test/test-typescript-types.ts
+++ b/test/test-typescript-types.ts
@@ -136,6 +136,42 @@ async function testCjsExtractorLoad() {
     );
 }
 
+// Test 17: Express integration - app.use() accepts the middleware, and
+// ClientCertRequest is usable as a route handler request type.
+// Regression coverage for the v2.0.0 type compatibility gap where
+// ClientCertRequest required a TLSSocket and Express's Socket-typed
+// req.socket failed overload resolution.
+import express from 'express';
+function testExpressIntegration() {
+    const app = express();
+
+    app.use(clientCertificateAuth((cert) => cert.subject.CN === 'admin'));
+
+    app.use(clientCertificateAuth((cert) => cert.subject.CN === 'admin', {
+        certificateSource: 'aws-alb',
+    }));
+
+    app.get('/whoami', (req: ClientCertRequest, res) => {
+        const _cn = req.clientCertificate?.subject?.CN;
+        void _cn;
+        res.json({});
+    });
+}
+
+// Test 18: Express integration via the CJS sync default export.
+function testExpressIntegrationCjsSync() {
+    const app = express();
+    const cjs = null as unknown as typeof cjsAuth;
+    app.use(cjs((cert) => cert.subject.CN === 'admin'));
+}
+
+// Test 19: Express integration via the CJS async load() entry.
+async function testExpressIntegrationCjsLoad() {
+    const app = express();
+    const cjs = await (null as unknown as typeof cjsAuth).load();
+    app.use(cjs((cert) => cert.subject.CN === 'admin'));
+}
+
 // Suppress unused variable warnings - this file is for type-checking only
 void _statusCode;
 void _syncMiddleware;
@@ -152,3 +188,6 @@ void checkInvalidProperty;
 void testCjsHelpersLoad;
 void testCjsParsersLoad;
 void testCjsExtractorLoad;
+void testExpressIntegration;
+void testExpressIntegrationCjsSync;
+void testExpressIntegrationCjsLoad;

--- a/test/test-unit-clientCertificateAuth.cjs
+++ b/test/test-unit-clientCertificateAuth.cjs
@@ -347,6 +347,34 @@ describe('clientCertificateAuth (CommonJS)', () => {
                     done();
                 });
             });
+
+            it('should pass 500 error to next() when getPeerCertificate is missing', done => {
+                const reqNoTlsMethod = {
+                    ...mockGoodReq,
+                    socket: { authorized: true }
+                };
+                const middleware = clientCertificateAuth(() => true);
+                middleware(reqNoTlsMethod, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.status, 500);
+                    assert.ok(err.message.includes('could not be retrieved'));
+                    done();
+                });
+            });
+
+            it('should pass 500 error to next() when getPeerCertificate is not a function', done => {
+                const reqBadTlsMethod = {
+                    ...mockGoodReq,
+                    socket: { authorized: true, getPeerCertificate: 'not a function' }
+                };
+                const middleware = clientCertificateAuth(() => true);
+                middleware(reqBadTlsMethod, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.status, 500);
+                    assert.ok(err.message.includes('could not be retrieved'));
+                    done();
+                });
+            });
         });
 
         describe('error message content', () => {
@@ -680,6 +708,27 @@ describe('clientCertificateAuth (CommonJS)', () => {
                 });
 
                 middleware(reqEmptyCert, mockRes, () => {
+                    setImmediate(() => {
+                        assert.ok(hookArgs, 'onRejected should have been called');
+                        assert.equal(hookArgs.cert, null);
+                        assert.equal(hookArgs.reason, 'certificate_not_retrievable');
+                        done();
+                    });
+                });
+            });
+
+            it('should call onRejected when getPeerCertificate is missing', done => {
+                let hookArgs = null;
+                const reqNoTlsMethod = {
+                    ...mockGoodReq,
+                    socket: { authorized: true }
+                };
+
+                const middleware = clientCertificateAuth(() => true, {
+                    onRejected: (cert, _req, reason) => { hookArgs = { cert, reason }; }
+                });
+
+                middleware(reqNoTlsMethod, mockRes, () => {
                     setImmediate(() => {
                         assert.ok(hookArgs, 'onRejected should have been called');
                         assert.equal(hookArgs.cert, null);


### PR DESCRIPTION
## Summary

- Widen `ClientCertRequest.socket` from `TLSSocket & {...}` to `net.Socket & {...optional TLS-specific fields...}` in both `.d.ts` and `.d.cts` so `app.use(clientCertificateAuth(...))` typechecks in real Express + TypeScript apps. Previously failed overload resolution because Express's `Request.socket: Socket` is broader than `TLSSocket`. Does not import `@types/express` into the published declarations.
- Add the same `getPeerCertificate` feature guard in the CJS sync middleware that the ESM extractor already has. The type widening above made `getPeerCertificate?:` optional in the published CJS type, which removed a compile-time shield that had been protecting a latent runtime crash at `lib/clientCertificateAuth.cjs:108`. Type and runtime now agree.
- Fix `docs/guide/typescript.md` claim that `ClientCertRequest` "extends Express's `Request`" (it extends `http.IncomingMessage` and is structurally compatible with Express).
- Update parallel JSDoc typedef in `lib/clientCertificateAuth.js` to mirror the widened `.d.ts`.