### PR TITLE
fix(security): do not leak diagnostic values into client error messages

### DIFF
--- a/lib/clientCertificateAuth.cjs
+++ b/lib/clientCertificateAuth.cjs
@@ -98,8 +98,7 @@ function clientCertificateAuth(callback, options = {}) {
         // Ensure that the certificate was validated at the protocol level
         if (!req.socket?.authorized) {
             safeCallHook(onRejected, null, req, 'socket_not_authorized');
-            const authError = req.socket?.authorizationError || 'unknown';
-            const e = new Error(`Unauthorized: Client certificate required (${authError})`);
+            const e = new Error('Unauthorized: Client certificate required');
             e.status = 401;
             return next(e);
         }

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -171,19 +171,15 @@ export default function clientCertificateAuth(callback, options = {}) {
       let statusCode = 401;
 
       switch (result.reason) {
-        case 'verification_header_mismatch': {
-          const verifyStatus = req.headers[verifyHeader.toLowerCase()];
-          errorMessage = `Unauthorized: Certificate verification failed (${verifyStatus || 'header missing'})`;
+        case 'verification_header_mismatch':
+          errorMessage = 'Unauthorized: Certificate verification failed';
           break;
-        }
         case 'header_missing_or_malformed':
           errorMessage = 'Unauthorized: Client certificate header missing or malformed';
           break;
-        case 'socket_not_authorized': {
-          const authError = req.socket?.authorizationError || 'unknown';
-          errorMessage = `Unauthorized: Client certificate required (${authError})`;
+        case 'socket_not_authorized':
+          errorMessage = 'Unauthorized: Client certificate required';
           break;
-        }
         case 'certificate_not_retrievable':
           errorMessage = 'Client certificate was authenticated but certificate information could not be retrieved.';
           statusCode = 500;

--- a/test/test-unit-clientCertificateAuth.cjs
+++ b/test/test-unit-clientCertificateAuth.cjs
@@ -303,7 +303,8 @@ describe('clientCertificateAuth (CommonJS)', () => {
                         assert.equal(callbackCalled, false);
                         assert.ok(err instanceof Error);
                         assert.equal(err.status, 401);
-                        assert.ok(err.message.includes('CERT_UNTRUSTED'));
+                        assert.equal(err.message, 'Unauthorized: Client certificate required');
+                        assert.ok(!err.message.includes('CERT_UNTRUSTED'));
                         done();
                     });
                 }
@@ -327,7 +328,7 @@ describe('clientCertificateAuth (CommonJS)', () => {
                 middleware(reqNoSocket, mockRes, (err) => {
                     assert.ok(err instanceof Error);
                     assert.equal(err.status, 401);
-                    assert.ok(err.message.includes('unknown'));
+                    assert.equal(err.message, 'Unauthorized: Client certificate required');
                     done();
                 });
             });
@@ -377,25 +378,22 @@ describe('clientCertificateAuth (CommonJS)', () => {
             });
         });
 
-        describe('error message content', () => {
-            it('should include "unknown" when authorizationError is missing', done => {
+        describe('client-facing error sanitization', () => {
+            it('returns a generic message when authorizationError is absent', done => {
                 const reqNoError = {
                     secure: true,
-                    socket: {
-                        authorized: false,
-                        getPeerCertificate: getMockPeerCertificate
-                    },
+                    socket: { authorized: false, getPeerCertificate: getMockPeerCertificate },
                     headers: {}
                 };
                 const middleware = clientCertificateAuth(() => true);
                 middleware(reqNoError, mockRes, (err) => {
                     assert.ok(err instanceof Error);
-                    assert.ok(err.message.includes('unknown'), `Expected "unknown" in: ${err.message}`);
+                    assert.equal(err.message, 'Unauthorized: Client certificate required');
                     done();
                 });
             });
 
-            it('should include the actual authorizationError when present', done => {
+            it('does not leak authorizationError into the client message when present', done => {
                 const reqWithError = {
                     secure: true,
                     socket: {
@@ -408,8 +406,8 @@ describe('clientCertificateAuth (CommonJS)', () => {
                 const middleware = clientCertificateAuth(() => true);
                 middleware(reqWithError, mockRes, (err) => {
                     assert.ok(err instanceof Error);
-                    assert.ok(err.message.includes('CERT_REVOKED'), `Expected "CERT_REVOKED" in: ${err.message}`);
-                    assert.ok(!err.message.includes('unknown'), 'Should not contain "unknown"');
+                    assert.equal(err.message, 'Unauthorized: Client certificate required');
+                    assert.ok(!err.message.includes('CERT_REVOKED'));
                     done();
                 });
             });
@@ -521,6 +519,7 @@ describe('clientCertificateAuth (CommonJS)', () => {
                         assert.ok(hookArgs, 'onRejected should have been called');
                         assert.equal(hookArgs.cert, null);
                         assert.equal(hookArgs.reason, 'socket_not_authorized');
+                        assert.equal(hookArgs.req.socket.authorizationError, 'CERT_UNTRUSTED');
                         done();
                     });
                 });

--- a/test/test-unit-clientCertificateAuth.js
+++ b/test/test-unit-clientCertificateAuth.js
@@ -308,7 +308,8 @@ describe('clientCertificateAuth', () => {
             assert.equal(callbackCalled, false);
             assert.ok(err instanceof Error);
             assert.equal(err.status, 401);
-            assert.ok(err.message.includes('CERT_UNTRUSTED'));
+            assert.equal(err.message, 'Unauthorized: Client certificate required');
+            assert.ok(!err.message.includes('CERT_UNTRUSTED'), 'authorizationError must not leak into client-facing message');
             done();
           });
         }
@@ -332,7 +333,7 @@ describe('clientCertificateAuth', () => {
         middleware(reqNoSocket, mockRes, (err) => {
           assert.ok(err instanceof Error);
           assert.equal(err.status, 401);
-          assert.ok(err.message.includes('unknown'));
+          assert.equal(err.message, 'Unauthorized: Client certificate required');
           done();
         });
       });
@@ -543,8 +544,7 @@ describe('clientCertificateAuth', () => {
           middleware(req, mockRes, (err) => {
             assert.ok(err instanceof Error);
             assert.equal(err.status, 401);
-            assert.ok(err.message.includes('Certificate verification failed'));
-            assert.ok(err.message.includes('header missing'));
+            assert.equal(err.message, 'Unauthorized: Certificate verification failed');
             done();
           });
         });
@@ -570,8 +570,31 @@ describe('clientCertificateAuth', () => {
           middleware(req, mockRes, (err) => {
             assert.ok(err instanceof Error);
             assert.equal(err.status, 401);
-            assert.ok(err.message.includes('Certificate verification failed'));
-            assert.ok(err.message.includes('FAILED:unable to verify'));
+            done();
+          });
+        });
+
+        it('should not leak the verifyHeader value into the client-facing message', done => {
+          const encodedCert = encodeURIComponent(testPem);
+          const req = {
+            secure: false,
+            socket: { authorized: false },
+            headers: {
+              'x-ssl-client-cert': encodedCert,
+              'x-ssl-client-verify': 'FAILED:reason-an-attacker-set'
+            }
+          };
+
+          const middleware = clientCertificateAuth(() => true, {
+            certificateHeader: 'X-SSL-Client-Cert',
+            headerEncoding: 'url-pem',
+            verifyHeader: 'X-SSL-Client-Verify',
+            verifyValue: 'SUCCESS'
+          });
+
+          middleware(req, mockRes, (err) => {
+            assert.equal(err.message, 'Unauthorized: Certificate verification failed');
+            assert.ok(!err.message.includes('FAILED:reason-an-attacker-set'));
             done();
           });
         });
@@ -789,26 +812,22 @@ describe('clientCertificateAuth', () => {
       });
     });
 
-    describe('error message content', () => {
-      it('should include "unknown" when authorizationError is missing', done => {
+    describe('client-facing error sanitization', () => {
+      it('returns a generic message when authorizationError is absent', done => {
         const reqNoError = {
           secure: true,
-          socket: {
-            authorized: false,
-            // authorizationError is undefined
-            getPeerCertificate: getMockPeerCertificate
-          },
+          socket: { authorized: false, getPeerCertificate: getMockPeerCertificate },
           headers: {}
         };
         const middleware = clientCertificateAuth(() => true);
         middleware(reqNoError, mockRes, (err) => {
           assert.ok(err instanceof Error);
-          assert.ok(err.message.includes('unknown'), `Expected "unknown" in: ${err.message}`);
+          assert.equal(err.message, 'Unauthorized: Client certificate required');
           done();
         });
       });
 
-      it('should include the actual authorizationError when present', done => {
+      it('does not leak authorizationError into the client message when present', done => {
         const reqWithError = {
           secure: true,
           socket: {
@@ -821,11 +840,12 @@ describe('clientCertificateAuth', () => {
         const middleware = clientCertificateAuth(() => true);
         middleware(reqWithError, mockRes, (err) => {
           assert.ok(err instanceof Error);
-          assert.ok(err.message.includes('CERT_REVOKED'), `Expected "CERT_REVOKED" in: ${err.message}`);
-          assert.ok(!err.message.includes('unknown'), 'Should not contain "unknown"');
+          assert.equal(err.message, 'Unauthorized: Client certificate required');
+          assert.ok(!err.message.includes('CERT_REVOKED'));
           done();
         });
       });
+
     });
 
     describe('req.clientCertificate', () => {
@@ -984,6 +1004,7 @@ describe('clientCertificateAuth', () => {
             assert.ok(hookArgs, 'onRejected should have been called');
             assert.equal(hookArgs.cert, null);
             assert.equal(hookArgs.reason, 'socket_not_authorized');
+            assert.equal(hookArgs.req.socket.authorizationError, 'CERT_UNTRUSTED');
             done();
           });
         });
@@ -1193,7 +1214,7 @@ describe('clientCertificateAuth', () => {
           headerEncoding: 'url-pem',
           verifyHeader: 'X-SSL-Client-Verify',
           verifyValue: 'SUCCESS',
-          onRejected: (cert, _req, reason) => { hookArgs = { cert, reason }; }
+          onRejected: (cert, req, reason) => { hookArgs = { cert, req, reason }; }
         });
 
         await new Promise(resolve => {
@@ -1202,6 +1223,7 @@ describe('clientCertificateAuth', () => {
               assert.ok(hookArgs, 'onRejected should have been called');
               assert.equal(hookArgs.cert, null);
               assert.equal(hookArgs.reason, 'verification_header_mismatch');
+              assert.equal(hookArgs.req.headers['x-ssl-client-verify'], 'FAILED');
               resolve();
             });
           });


### PR DESCRIPTION
socket_not_authorized (both runtimes) previously interpolated `req.socket.authorizationError` (OpenSSL codes like `CERT_HAS_EXPIRED`, `UNABLE_TO_GET_ISSUER_CERT`) into the message passed to `next(err)`. verification_header_mismatch (ESM) reflected `req.headers[verifyHeader]` similarly. Both now use static generic strings. Operators who want the verbose values for logging can still read them via the `req` argument passed to `onRejected`.