### PR TITLE
docs: add v2 upgrade notes and clarify verifyValue exact-match

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,6 +815,15 @@ The E2E tests spin up real reverse proxies, generate fresh certificates, and ver
 - **When using header-based auth**, ensure your proxy strips certificate headers from external requests
 - Use `verifyHeader`/`verifyValue` as defense-in-depth when using header-based authentication
 
+## Upgrading from 1.x
+
+v2.0.0 introduced two behavior changes:
+
+- **Validation callbacks must return exactly `true`.** Previously any truthy value (`'admin'`, `1`, an object) authorized; now only `true` (or a `Promise`/thenable resolving to `true`) does. Callbacks that returned ad-hoc truthy values (e.g., `return cert.subject.CN`) must be rewritten to explicit `return true` / `return false`.
+- **Header options are validated at construction.** Typos like `certificateSource: 'aws-alp'` now throw at app startup instead of failing at request time.
+
+See the [CHANGELOG](./CHANGELOG.md) for the full v2.0.0 entry.
+
 ## Troubleshooting
 
 ### `DEPTH_ZERO_SELF_SIGNED_CERT` error

--- a/docs/guide/reverse-proxy.md
+++ b/docs/guide/reverse-proxy.md
@@ -122,6 +122,8 @@ app.use(clientCertificateAuth(checkAuth, {
 }));
 ```
 
+The `verifyValue` comparison is exact (case-sensitive, no whitespace trimming); set it to the exact string your proxy emits.
+
 Example nginx configuration:
 ```nginx
 # Strip any existing headers from clients

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -85,3 +85,12 @@ See the [WebSocket Support](./websocket) page for complete examples with both `w
 This package is an ES module with a CJS compatibility wrapper. The sync `require()` entry only supports socket-based mTLS; reverse proxy options require the async `load()` function. Subpath exports (`/helpers`, `/extractor`, `/parsers`) also need `load()` in CJS.
 
 For a full breakdown of what's available in each mode, see the [TypeScript & CJS](./typescript) page.
+
+## Upgrading from 1.x
+
+v2.0.0 introduced two behavior changes:
+
+- **Validation callbacks must return exactly `true`.** Previously any truthy value (`'admin'`, `1`, an object) authorized; now only `true` (or a `Promise`/thenable resolving to `true`) does. Callbacks that returned ad-hoc truthy values (e.g., `return cert.subject.CN`) must be rewritten to explicit `return true` / `return false`.
+- **Header options are validated at construction.** Typos like `certificateSource: 'aws-alp'` now throw at app startup instead of failing at request time.
+
+See the [CHANGELOG](https://github.com/tgies/client-certificate-auth/blob/master/CHANGELOG.md) for the full v2.0.0 entry.

--- a/lib/clientCertificateAuth.d.ts
+++ b/lib/clientCertificateAuth.d.ts
@@ -106,6 +106,7 @@ export interface ClientCertificateAuthOptions {
     /**
      * Expected value indicating successful certificate verification.
      * If verifyHeader is set, requests are rejected unless the header matches this value.
+     * Comparison is exact (case-sensitive, no whitespace trimming).
      * Example: 'SUCCESS' for nginx.
      */
     verifyValue?: string;

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -49,6 +49,7 @@ function isThenable(value) {
  *   upstream proxy (e.g., 'X-SSL-Client-Verify'). Must be used with verifyValue.
  * @property {string} [verifyValue] - Expected value indicating successful verification (e.g., 'SUCCESS').
  *   If verifyHeader is set, requests are rejected unless the header matches this value.
+ *   Comparison is exact (case-sensitive, no whitespace trimming); set this to the exact string your proxy emits.
  * @property {(cert: import('tls').PeerCertificate, req: ClientCertRequest) => void | Promise<void>} [onAuthenticated] -
  *   Called when a client is successfully authenticated. Fire-and-forget.
  * @property {(cert: import('tls').PeerCertificate | null, req: ClientCertRequest, reason: string) => void | Promise<void>} [onRejected] -


### PR DESCRIPTION
Adds an "Upgrading from 1.x" section to the README and the docs site (covers strict-true callback requirement plus constructor-time header-option validation). Also clarifies in the verifyValue JSDoc, `.d.ts`, and the reverse-proxy guide that the comparison is exact match (case-sensitive, no whitespace trimming).