### PR TITLE
fix(extractor): share option validation with middleware constructor

### DIFF
--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -5,10 +5,7 @@
  * @license MIT
  */
 
-import { extractClientCertificate } from './extractor.js';
-import { PRESETS } from './parsers.js';
-
-const VALID_ENCODINGS = ['url-pem', 'url-pem-aws', 'xfcc', 'base64-der', 'rfc9440'];
+import { extractClientCertificate, validateExtractorOptions } from './extractor.js';
 
 /**
  * Duck-typed thenable check per Promises/A+: an object or function with
@@ -94,6 +91,8 @@ export default function clientCertificateAuth(callback, options = {}) {
     throw new TypeError('client-certificate-auth: callback must be a function');
   }
 
+  validateExtractorOptions(options);
+
   const {
     certificateSource,
     certificateHeader,
@@ -105,30 +104,6 @@ export default function clientCertificateAuth(callback, options = {}) {
     onAuthenticated,
     onRejected,
   } = options;
-
-  if ((verifyHeader && !verifyValue) || (!verifyHeader && verifyValue)) {
-    throw new Error(
-      'client-certificate-auth: verifyHeader and verifyValue must both be provided together, or both omitted'
-    );
-  }
-
-  if (certificateSource && !Object.hasOwn(PRESETS, certificateSource)) {
-    throw new Error(
-      `client-certificate-auth: unknown certificateSource '${certificateSource}'. Valid values: ${Object.keys(PRESETS).join(', ')}`
-    );
-  }
-
-  if (headerEncoding && !VALID_ENCODINGS.includes(headerEncoding)) {
-    throw new Error(
-      `client-certificate-auth: unknown headerEncoding '${headerEncoding}'. Valid values: ${VALID_ENCODINGS.join(', ')}`
-    );
-  }
-
-  if (certificateHeader && !certificateSource && !headerEncoding) {
-    throw new Error(
-      'client-certificate-auth: certificateHeader requires headerEncoding (or a certificateSource preset that supplies one)'
-    );
-  }
 
   /**
    * Safely call a hook function without blocking or throwing.

--- a/lib/extractor.d.ts
+++ b/lib/extractor.d.ts
@@ -58,6 +58,13 @@ export function extractClientCertificate(req: {
         getPeerCertificate?: (detailed: boolean) => import("tls").PeerCertificate;
     };
 }, options?: ExtractorOptions): ExtractionResult;
+/**
+ * Validate options shared by `extractClientCertificate` and the middleware constructor.
+ * Throws on unknown `certificateSource`, unknown `headerEncoding`,
+ * `certificateHeader` without an encoding source, or only one of `verifyHeader`/`verifyValue`.
+ * Omitted or `undefined` options are treated as the empty object; explicit `null` throws.
+ */
+export function validateExtractorOptions(options?: ExtractorOptions): void;
 export type ExtractionResult = {
     /**
      * - Whether extraction succeeded

--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -4,7 +4,47 @@
  * @license MIT
  */
 
-import { getCertificateFromHeaders } from './parsers.js';
+import { getCertificateFromHeaders, PRESETS } from './parsers.js';
+
+const VALID_ENCODINGS = ['url-pem', 'url-pem-aws', 'xfcc', 'base64-der', 'rfc9440'];
+
+/**
+ * Validate options shared by `extractClientCertificate` and the middleware
+ * constructor. Throws on misconfiguration (unknown preset, unknown encoding,
+ * `certificateHeader` without an encoding source, or only one of
+ * `verifyHeader`/`verifyValue`). Omitted or `undefined` options are treated
+ * as the empty object; explicit `null` will throw a `TypeError`.
+ *
+ * @param {ExtractorOptions} [options]
+ * @throws {Error} when options are malformed
+ */
+export function validateExtractorOptions(options = {}) {
+  const { certificateSource, certificateHeader, headerEncoding, verifyHeader, verifyValue } = options;
+
+  if ((verifyHeader && !verifyValue) || (!verifyHeader && verifyValue)) {
+    throw new Error(
+      'client-certificate-auth: verifyHeader and verifyValue must both be provided together, or both omitted'
+    );
+  }
+
+  if (certificateSource && !Object.hasOwn(PRESETS, certificateSource)) {
+    throw new Error(
+      `client-certificate-auth: unknown certificateSource '${certificateSource}'. Valid values: ${Object.keys(PRESETS).join(', ')}`
+    );
+  }
+
+  if (headerEncoding && !VALID_ENCODINGS.includes(headerEncoding)) {
+    throw new Error(
+      `client-certificate-auth: unknown headerEncoding '${headerEncoding}'. Valid values: ${VALID_ENCODINGS.join(', ')}`
+    );
+  }
+
+  if (certificateHeader && !certificateSource && !headerEncoding) {
+    throw new Error(
+      'client-certificate-auth: certificateHeader requires headerEncoding (or a certificateSource preset that supplies one)'
+    );
+  }
+}
 
 /**
  * @typedef {Object} ExtractionResult
@@ -66,6 +106,8 @@ import { getCertificateFromHeaders } from './parsers.js';
  * });
  */
 export function extractClientCertificate(req, options = {}) {
+  validateExtractorOptions(options);
+
   const {
     certificateSource,
     certificateHeader,
@@ -75,13 +117,6 @@ export function extractClientCertificate(req, options = {}) {
     verifyHeader,
     verifyValue,
   } = options;
-
-  // Validate verifyHeader/verifyValue pairing
-  if ((verifyHeader && !verifyValue) || (!verifyHeader && verifyValue)) {
-    throw new Error(
-      'extractClientCertificate: verifyHeader and verifyValue must both be provided together, or both omitted'
-    );
-  }
 
   const useHeaders = Boolean(certificateSource || certificateHeader);
   let cert = null;

--- a/test/test-unit-extractor.js
+++ b/test/test-unit-extractor.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { extractClientCertificate } from '../lib/extractor.js';
+import { extractClientCertificate, validateExtractorOptions } from '../lib/extractor.js';
 
 // Mock certificate for socket tests
 const getMockPeerCertificate = () => ({
@@ -74,6 +74,74 @@ describe('extractClientCertificate', () => {
     it('should not throw when neither verifyHeader nor verifyValue is set', () => {
       const req = { headers: {}, socket: { authorized: false } };
       assert.doesNotThrow(() => extractClientCertificate(req, {}));
+    });
+
+    it('should not throw when options argument is omitted entirely', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      assert.doesNotThrow(() => extractClientCertificate(req));
+    });
+
+    it('should throw when certificateSource is unknown', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      assert.throws(
+        () => extractClientCertificate(req, { certificateSource: 'aws-alp' }),
+        { name: 'Error', message: /unknown certificateSource 'aws-alp'/ }
+      );
+    });
+
+    it('should throw when certificateSource is an inherited Object.prototype key', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      for (const key of ['toString', 'constructor', 'hasOwnProperty', '__proto__']) {
+        assert.throws(
+          () => extractClientCertificate(req, { certificateSource: key }),
+          { name: 'Error', message: new RegExp(`unknown certificateSource '${key}'`) },
+          `${key} should be rejected as an inherited prototype key`
+        );
+      }
+    });
+
+    it('should throw when headerEncoding is unknown', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      assert.throws(
+        () => extractClientCertificate(req, {
+          certificateHeader: 'X-Cert',
+          headerEncoding: 'url-perm',
+        }),
+        { name: 'Error', message: /unknown headerEncoding 'url-perm'/ }
+      );
+    });
+
+    it('should throw when certificateHeader is set without headerEncoding or preset', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      assert.throws(
+        () => extractClientCertificate(req, { certificateHeader: 'X-Cert' }),
+        { name: 'Error', message: /certificateHeader requires headerEncoding/ }
+      );
+    });
+
+    it('should not throw when certificateHeader pairs with a preset (encoding from preset)', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      assert.doesNotThrow(() =>
+        extractClientCertificate(req, {
+          certificateSource: 'aws-alb',
+          certificateHeader: 'X-Override',
+        })
+      );
+    });
+
+    it('should not throw when certificateSource alone is valid', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      assert.doesNotThrow(() =>
+        extractClientCertificate(req, { certificateSource: 'envoy' })
+      );
+    });
+
+    it('should not throw when validateExtractorOptions is called with no arguments', () => {
+      assert.doesNotThrow(() => validateExtractorOptions());
+    });
+
+    it('should throw TypeError when validateExtractorOptions is called with null', () => {
+      assert.throws(() => validateExtractorOptions(null), { name: 'TypeError' });
     });
   });
 


### PR DESCRIPTION
`extractClientCertificate()` previously only validated the `verifyHeader`/`verifyValue` pairing; typos in `certificateSource` or `headerEncoding` silently degraded to `{ success: false, reason: 'header_missing_or_malformed' }` instead of throwing like the middleware constructor does. Moves the four checks into a shared `validateExtractorOptions()` helper exported from `lib/extractor.js` and calls it from both entry points.