### PR TITLE
chore(deps): security-only dependabot entry for maint/1.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,15 @@ updates:
           - "minor"
           - "patch"
 
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/examples/e2e-mtls"
+    target-branch: "maint/1.x"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Adds an npm entry targeting maint/1.x with `open-pull-requests-limit: 0`, which disables routine version-update PRs while allowing Dependabot to create security updates against maint/1.x.