### PR TITLE
chore(examples): bump e2e example to client-certificate-auth 2.0.1

### DIFF
--- a/examples/e2e-mtls/package-lock.json
+++ b/examples/e2e-mtls/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "e2e-mtls-example",
       "dependencies": {
-        "client-certificate-auth": "^2.0.0",
+        "client-certificate-auth": "^2.0.1",
         "express": "^5.2.1"
       }
     },
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/client-certificate-auth": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/client-certificate-auth/-/client-certificate-auth-2.0.0.tgz",
-      "integrity": "sha512-xOyp+oyAV7dYGBdKcn+V0NdTbFda3x/Hi+oorUh93laLt9mvE/HAleHp1KOZmqdX6rlZANPByQ3MiI0l8r+3vw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/client-certificate-auth/-/client-certificate-auth-2.0.1.tgz",
+      "integrity": "sha512-o1xLqxTvJ5K4K9IHdbEzIOuvUNPPcy/kE/Pqbs1DXWMQGaZn9KrTpg4ZOGK0oolBBMny/lf+n5O0IKv9NzSttg==",
       "license": "MIT",
       "engines": {
         "node": ">= 20"

--- a/examples/e2e-mtls/package.json
+++ b/examples/e2e-mtls/package.json
@@ -9,7 +9,7 @@
     "test": "node test-client.js"
   },
   "dependencies": {
-    "client-certificate-auth": "^2.0.0",
+    "client-certificate-auth": "^2.0.1",
     "express": "^5.2.1"
   }
 }


### PR DESCRIPTION
Refreshes `examples/e2e-mtls` to pin 2.0.1.