### PR TITLE
fix: thenable handling in audit hooks and colon normalization in allowFingerprints

### DIFF
--- a/lib/clientCertificateAuth.cjs
+++ b/lib/clientCertificateAuth.cjs
@@ -85,8 +85,8 @@ function clientCertificateAuth(callback, options = {}) {
         queueMicrotask(() => {
             try {
                 const result = hook(...args);
-                if (result instanceof Promise) {
-                    result.catch(err => console.error('client-certificate-auth: hook error:', err));
+                if (isThenable(result)) {
+                    Promise.resolve(result).catch(err => console.error('client-certificate-auth: hook error:', err));
                 }
             } catch (err) {
                 console.error('client-certificate-auth: hook error:', err);

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -118,8 +118,8 @@ export default function clientCertificateAuth(callback, options = {}) {
     queueMicrotask(() => {
       try {
         const result = hook(...args);
-        if (result instanceof Promise) {
-          result.catch(err => console.error('client-certificate-auth: hook error:', err));
+        if (isThenable(result)) {
+          Promise.resolve(result).catch(err => console.error('client-certificate-auth: hook error:', err));
         }
       } catch (err) {
         console.error('client-certificate-auth: hook error:', err);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -38,7 +38,8 @@ export function allowCN(names) {
  * Create a validation callback that allows certificates with matching fingerprints.
  * Supports SHA-1 fingerprints (compared against cert.fingerprint) and SHA-256
  * fingerprints with "SHA256:" prefix (compared against cert.fingerprint256).
- * Fingerprints without a prefix are treated as SHA-1.
+ * Fingerprints without a prefix are treated as SHA-1. Hex inputs are
+ * normalized: case and colon delimiters are ignored on both sides.
  *
  * @param {string[]} fingerprints - Allowed fingerprints
  * @returns {ValidationCallback}
@@ -46,28 +47,30 @@ export function allowCN(names) {
  * @example
  * app.use(clientCertificateAuth(allowFingerprints([
  *   'SHA256:AB:CD:EF:...',  // matched against cert.fingerprint256
- *   'AB:CD:EF:...'          // matched against cert.fingerprint (SHA-1)
+ *   'AB:CD:EF:...',         // colon-delimited, matched against cert.fingerprint
+ *   'ABCDEF...'             // contiguous hex also matches cert.fingerprint
  * ])));
  */
 export function allowFingerprints(fingerprints) {
+    const normalize = (fp) => fp.toUpperCase().replace(/:/g, '');
     const sha256Allowed = new Set();
     const sha1Allowed = new Set();
 
     for (const fp of fingerprints) {
         const upper = fp.toUpperCase();
         if (upper.startsWith('SHA256:')) {
-            sha256Allowed.add(upper.slice(7));
+            sha256Allowed.add(normalize(upper.slice(7)));
         } else {
-            sha1Allowed.add(upper);
+            sha1Allowed.add(normalize(upper));
         }
     }
 
     return (cert) => {
         if (sha1Allowed.size > 0 && cert.fingerprint) {
-            if (sha1Allowed.has(cert.fingerprint.toUpperCase())) {return true;}
+            if (sha1Allowed.has(normalize(cert.fingerprint))) {return true;}
         }
         if (sha256Allowed.size > 0 && cert.fingerprint256) {
-            if (sha256Allowed.has(cert.fingerprint256.toUpperCase())) {return true;}
+            if (sha256Allowed.has(normalize(cert.fingerprint256))) {return true;}
         }
         return false;
     };

--- a/test/test-unit-clientCertificateAuth.cjs
+++ b/test/test-unit-clientCertificateAuth.cjs
@@ -695,6 +695,56 @@ describe('clientCertificateAuth (CommonJS)', () => {
                 });
             });
 
+            it('should catch and log rejections from non-native thenable returned by onAuthenticated', done => {
+                let errorLogged = false;
+                console.error = (...args) => {
+                    if (args[0]?.includes?.('hook error')) {
+                        errorLogged = true;
+                    }
+                };
+
+                const middleware = clientCertificateAuth(() => true, {
+                    onAuthenticated: () => ({
+                        then(_resolve, reject) {
+                            reject(new Error('Custom thenable explosion'));
+                        }
+                    })
+                });
+
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.equal(err, undefined, 'Request should succeed despite hook error');
+                    setTimeout(() => {
+                        assert.ok(errorLogged, 'Error should have been logged');
+                        done();
+                    }, 10);
+                });
+            });
+
+            it('should catch and log rejections from non-native thenable returned by onRejected', done => {
+                let errorLogged = false;
+                console.error = (...args) => {
+                    if (args[0]?.includes?.('hook error')) {
+                        errorLogged = true;
+                    }
+                };
+
+                const middleware = clientCertificateAuth(() => false, {
+                    onRejected: () => ({
+                        then(_resolve, reject) {
+                            reject(new Error('Custom thenable explosion'));
+                        }
+                    })
+                });
+
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.equal(err?.status, 401, 'Callback returning false should produce 401');
+                    setTimeout(() => {
+                        assert.ok(errorLogged, 'Error should have been logged');
+                        done();
+                    }, 10);
+                });
+            });
+
             it('should call onRejected when cert cannot be retrieved', done => {
                 let hookArgs = null;
                 const reqEmptyCert = {

--- a/test/test-unit-clientCertificateAuth.js
+++ b/test/test-unit-clientCertificateAuth.js
@@ -1146,6 +1146,56 @@ describe('clientCertificateAuth', () => {
         });
       });
 
+      it('should catch and log rejections from non-native thenable returned by onAuthenticated', done => {
+        let errorLogged = false;
+        console.error = (...args) => {
+          if (args[0]?.includes?.('hook error')) {
+            errorLogged = true;
+          }
+        };
+
+        const middleware = clientCertificateAuth(() => true, {
+          onAuthenticated: () => ({
+            then(_resolve, reject) {
+              reject(new Error('Custom thenable explosion'));
+            }
+          })
+        });
+
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.equal(err, undefined, 'Request should succeed despite hook error');
+          setTimeout(() => {
+            assert.ok(errorLogged, 'Error should have been logged');
+            done();
+          }, 10);
+        });
+      });
+
+      it('should catch and log rejections from non-native thenable returned by onRejected', done => {
+        let errorLogged = false;
+        console.error = (...args) => {
+          if (args[0]?.includes?.('hook error')) {
+            errorLogged = true;
+          }
+        };
+
+        const middleware = clientCertificateAuth(() => false, {
+          onRejected: () => ({
+            then(_resolve, reject) {
+              reject(new Error('Custom thenable explosion'));
+            }
+          })
+        });
+
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.equal(err?.status, 401, 'Callback returning false should produce 401');
+          setTimeout(() => {
+            assert.ok(errorLogged, 'Error should have been logged');
+            done();
+          }, 10);
+        });
+      });
+
       it('should not call hooks when they are not provided', done => {
         // This test just verifies no errors when hooks are undefined
         const middleware = clientCertificateAuth(() => true);

--- a/test/test-unit-helpers.js
+++ b/test/test-unit-helpers.js
@@ -138,6 +138,16 @@ describe('helpers', () => {
             assert.equal(check(certMixedFp), true);
         });
 
+        it('should match SHA-1 fingerprint supplied as contiguous hex against colon-delimited cert', () => {
+            const check = allowFingerprints(['ABCDEF0123456789ABCDEF0123456789ABCDEF01']);
+            assert.equal(check(mockCert), true);
+        });
+
+        it('should match SHA-1 fingerprint with arbitrary colon placement', () => {
+            const check = allowFingerprints(['ABCD:EF0123456789AB:CDEF0123456789ABCDEF01']);
+            assert.equal(check(mockCert), true);
+        });
+
         // SHA-256 (with SHA256: prefix) tests — compared against cert.fingerprint256
         it('should match SHA-256 fingerprint with SHA256: prefix against cert.fingerprint256', () => {
             const check = allowFingerprints([
@@ -149,6 +159,13 @@ describe('helpers', () => {
         it('should match SHA-256 fingerprint case-insensitively', () => {
             const check = allowFingerprints([
                 'sha256:aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99',
+            ]);
+            assert.equal(check(mockCert), true);
+        });
+
+        it('should match SHA-256 fingerprint with prefix and contiguous hex digest', () => {
+            const check = allowFingerprints([
+                'SHA256:AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899',
             ]);
             assert.equal(check(mockCert), true);
         });


### PR DESCRIPTION
## Summary

Two unrelated correctness fixes against v2.0.1, bundled for a single v2.0.2 release.

- **safeCallHook** gated on `result instanceof Promise`, so a non-native thenable returned from `onAuthenticated` or `onRejected` slipped past the guard and surfaced as an unhandled rejection. Switched to the existing `isThenable` helper and `Promise.resolve(...).catch(...)`. ESM and CJS modules.
- **allowFingerprints** only uppercased inputs; callers passing contiguous hex (`ABCDEF...`) silently failed to match a cert whose `cert.fingerprint` was `AB:CD:EF...`. Normalized both sides with the same `toUpperCase().replace(/:/g, '')` shape `allowSerial` already uses.

## Test plan

- [ ] `npm test` (420 tests pass, including 7 new: 2 ESM + 2 CJS for non-native thenable hooks, 3 for fingerprint colon-stripping)
- [ ] `npm run lint` clean
- [ ] `npm run typecheck` clean
- [ ] `npx stryker run --mutate 'lib/clientCertificateAuth.js,lib/clientCertificateAuth.cjs,lib/helpers.js'` (95.74% mutation score; one survivor is an equivalent mutant from the symmetric `normalize` helper, matching `allowSerial`'s pattern)
- [ ] CI green