### PR TITLE
fix(hooks): adopt thenables returned from audit hooks via Promise.resolve

### DIFF
--- a/lib/clientCertificateAuth.cjs
+++ b/lib/clientCertificateAuth.cjs
@@ -85,8 +85,8 @@ function clientCertificateAuth(callback, options = {}) {
         queueMicrotask(() => {
             try {
                 const result = hook(...args);
-                if (result instanceof Promise) {
-                    result.catch(err => console.error('client-certificate-auth: hook error:', err));
+                if (isThenable(result)) {
+                    Promise.resolve(result).catch(err => console.error('client-certificate-auth: hook error:', err));
                 }
             } catch (err) {
                 console.error('client-certificate-auth: hook error:', err);

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -118,8 +118,8 @@ export default function clientCertificateAuth(callback, options = {}) {
     queueMicrotask(() => {
       try {
         const result = hook(...args);
-        if (result instanceof Promise) {
-          result.catch(err => console.error('client-certificate-auth: hook error:', err));
+        if (isThenable(result)) {
+          Promise.resolve(result).catch(err => console.error('client-certificate-auth: hook error:', err));
         }
       } catch (err) {
         console.error('client-certificate-auth: hook error:', err);

--- a/test/test-unit-clientCertificateAuth.cjs
+++ b/test/test-unit-clientCertificateAuth.cjs
@@ -695,6 +695,56 @@ describe('clientCertificateAuth (CommonJS)', () => {
                 });
             });
 
+            it('should catch and log rejections from non-native thenable returned by onAuthenticated', done => {
+                let errorLogged = false;
+                console.error = (...args) => {
+                    if (args[0]?.includes?.('hook error')) {
+                        errorLogged = true;
+                    }
+                };
+
+                const middleware = clientCertificateAuth(() => true, {
+                    onAuthenticated: () => ({
+                        then(_resolve, reject) {
+                            reject(new Error('Custom thenable explosion'));
+                        }
+                    })
+                });
+
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.equal(err, undefined, 'Request should succeed despite hook error');
+                    setTimeout(() => {
+                        assert.ok(errorLogged, 'Error should have been logged');
+                        done();
+                    }, 10);
+                });
+            });
+
+            it('should catch and log rejections from non-native thenable returned by onRejected', done => {
+                let errorLogged = false;
+                console.error = (...args) => {
+                    if (args[0]?.includes?.('hook error')) {
+                        errorLogged = true;
+                    }
+                };
+
+                const middleware = clientCertificateAuth(() => false, {
+                    onRejected: () => ({
+                        then(_resolve, reject) {
+                            reject(new Error('Custom thenable explosion'));
+                        }
+                    })
+                });
+
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.equal(err?.status, 401, 'Callback returning false should produce 401');
+                    setTimeout(() => {
+                        assert.ok(errorLogged, 'Error should have been logged');
+                        done();
+                    }, 10);
+                });
+            });
+
             it('should call onRejected when cert cannot be retrieved', done => {
                 let hookArgs = null;
                 const reqEmptyCert = {

--- a/test/test-unit-clientCertificateAuth.js
+++ b/test/test-unit-clientCertificateAuth.js
@@ -1146,6 +1146,56 @@ describe('clientCertificateAuth', () => {
         });
       });
 
+      it('should catch and log rejections from non-native thenable returned by onAuthenticated', done => {
+        let errorLogged = false;
+        console.error = (...args) => {
+          if (args[0]?.includes?.('hook error')) {
+            errorLogged = true;
+          }
+        };
+
+        const middleware = clientCertificateAuth(() => true, {
+          onAuthenticated: () => ({
+            then(_resolve, reject) {
+              reject(new Error('Custom thenable explosion'));
+            }
+          })
+        });
+
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.equal(err, undefined, 'Request should succeed despite hook error');
+          setTimeout(() => {
+            assert.ok(errorLogged, 'Error should have been logged');
+            done();
+          }, 10);
+        });
+      });
+
+      it('should catch and log rejections from non-native thenable returned by onRejected', done => {
+        let errorLogged = false;
+        console.error = (...args) => {
+          if (args[0]?.includes?.('hook error')) {
+            errorLogged = true;
+          }
+        };
+
+        const middleware = clientCertificateAuth(() => false, {
+          onRejected: () => ({
+            then(_resolve, reject) {
+              reject(new Error('Custom thenable explosion'));
+            }
+          })
+        });
+
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.equal(err?.status, 401, 'Callback returning false should produce 401');
+          setTimeout(() => {
+            assert.ok(errorLogged, 'Error should have been logged');
+            done();
+          }, 10);
+        });
+      });
+
       it('should not call hooks when they are not provided', done => {
         // This test just verifies no errors when hooks are undefined
         const middleware = clientCertificateAuth(() => true);


### PR DESCRIPTION
`safeCallHook` gated on `result instanceof Promise`, so non-native thenables returned from `onAuthenticated`/`onRejected` slipped past the guard and surfaced as unhandled rejections. Switches to the existing `isThenable` helper with `Promise.resolve(...).catch(...)`.