### PR TITLE
fix(helpers): strip colons from fingerprint inputs in allowFingerprints

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -38,7 +38,8 @@ export function allowCN(names) {
  * Create a validation callback that allows certificates with matching fingerprints.
  * Supports SHA-1 fingerprints (compared against cert.fingerprint) and SHA-256
  * fingerprints with "SHA256:" prefix (compared against cert.fingerprint256).
- * Fingerprints without a prefix are treated as SHA-1.
+ * Fingerprints without a prefix are treated as SHA-1. Hex inputs are
+ * normalized: case and colon delimiters are ignored on both sides.
  *
  * @param {string[]} fingerprints - Allowed fingerprints
  * @returns {ValidationCallback}
@@ -46,28 +47,30 @@ export function allowCN(names) {
  * @example
  * app.use(clientCertificateAuth(allowFingerprints([
  *   'SHA256:AB:CD:EF:...',  // matched against cert.fingerprint256
- *   'AB:CD:EF:...'          // matched against cert.fingerprint (SHA-1)
+ *   'AB:CD:EF:...',         // colon-delimited, matched against cert.fingerprint
+ *   'ABCDEF...'             // contiguous hex also matches cert.fingerprint
  * ])));
  */
 export function allowFingerprints(fingerprints) {
+    const normalize = (fp) => fp.toUpperCase().replace(/:/g, '');
     const sha256Allowed = new Set();
     const sha1Allowed = new Set();
 
     for (const fp of fingerprints) {
         const upper = fp.toUpperCase();
         if (upper.startsWith('SHA256:')) {
-            sha256Allowed.add(upper.slice(7));
+            sha256Allowed.add(normalize(upper.slice(7)));
         } else {
-            sha1Allowed.add(upper);
+            sha1Allowed.add(normalize(upper));
         }
     }
 
     return (cert) => {
         if (sha1Allowed.size > 0 && cert.fingerprint) {
-            if (sha1Allowed.has(cert.fingerprint.toUpperCase())) {return true;}
+            if (sha1Allowed.has(normalize(cert.fingerprint))) {return true;}
         }
         if (sha256Allowed.size > 0 && cert.fingerprint256) {
-            if (sha256Allowed.has(cert.fingerprint256.toUpperCase())) {return true;}
+            if (sha256Allowed.has(normalize(cert.fingerprint256))) {return true;}
         }
         return false;
     };

--- a/test/test-unit-helpers.js
+++ b/test/test-unit-helpers.js
@@ -138,6 +138,16 @@ describe('helpers', () => {
             assert.equal(check(certMixedFp), true);
         });
 
+        it('should match SHA-1 fingerprint supplied as contiguous hex against colon-delimited cert', () => {
+            const check = allowFingerprints(['ABCDEF0123456789ABCDEF0123456789ABCDEF01']);
+            assert.equal(check(mockCert), true);
+        });
+
+        it('should match SHA-1 fingerprint with arbitrary colon placement', () => {
+            const check = allowFingerprints(['ABCD:EF0123456789AB:CDEF0123456789ABCDEF01']);
+            assert.equal(check(mockCert), true);
+        });
+
         // SHA-256 (with SHA256: prefix) tests — compared against cert.fingerprint256
         it('should match SHA-256 fingerprint with SHA256: prefix against cert.fingerprint256', () => {
             const check = allowFingerprints([
@@ -149,6 +159,13 @@ describe('helpers', () => {
         it('should match SHA-256 fingerprint case-insensitively', () => {
             const check = allowFingerprints([
                 'sha256:aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99',
+            ]);
+            assert.equal(check(mockCert), true);
+        });
+
+        it('should match SHA-256 fingerprint with prefix and contiguous hex digest', () => {
+            const check = allowFingerprints([
+                'SHA256:AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899',
             ]);
             assert.equal(check(mockCert), true);
         });


### PR DESCRIPTION
`cert.fingerprint`/`cert.fingerprint256` from Node are colon-delimited uppercase hex, but `allowFingerprints` only uppercased inputs, so callers passing contiguous hex silently failed to match. Normalizes both sides with `toUpperCase().replace(/:/g, '')`, matching `allowSerial`.