### PR TITLE
chore(release): v2.1.0: new presets, `chainHeader` option, `lambda`/`fetch` modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-05-20
+
+### Added
+
+- **`azure-app-service` preset** — Azure App Service forwards the validated client certificate as the body of a PEM cert (bare base64 DER, no delimiters) in the `X-ARR-ClientCert` header. The new preset pairs that header name with the existing `base64-der` encoding. The same header convention is used by IIS/ARR generally; Azure Application Gateway and Azure API Management use different formats and remain documentation-only for now.
+- **`cloudflare-rfc9440` preset** — Cloudflare's March 2026 mTLS forwarding update introduced first-class RFC 9440 support, setting the standard `Client-Cert` and `Client-Cert-Chain` request headers via Transform Rules. The new preset pairs the standard header names with the existing `rfc9440` encoding and ships alongside the existing `cloudflare` preset (which continues to read the legacy `Cf-Client-Cert-Der-Base64` family).
+- **`aws-alb-verify` preset** — AWS ALB in mTLS verify mode emits the validated leaf certificate as URL-encoded PEM in `X-Amzn-Mtls-Clientcert-Leaf` (the leaf only, not the full chain). Pairs that header name with the `url-pem-aws` encoding. Complements the existing `aws-alb` preset for passthrough mode.
+- **`chainHeader` extractor option** — RFC 9440 splits the leaf cert and the cert chain into two separate headers (`Client-Cert` and `Client-Cert-Chain`). The extractor now accepts an optional `chainHeader` paired with `certificateHeader` (or supplied automatically by a preset). The chain header's value is split on commas per RFC 9440 structured-field list semantics, each item parsed with the same `headerEncoding`, and the resulting certificates linked via `issuerCertificate` after the leaf. Primary use case is RFC 9440-style two-header schemes; the same option is available for custom two-header configurations.
+- **`client-certificate-auth/lambda` subpath** — `extractClientCertificateFromLambdaEvent(event)` extracts the validated client certificate from an AWS API Gateway Lambda event. Handles both v2.0 (HTTP API; `event.requestContext.authentication.clientCert`) and v1.0 (REST API; `event.requestContext.identity.clientCert`) payload formats. Returns the same `ExtractionResult` shape as the core extractor for cross-call uniformity. New rejection reasons: `lambda_event_missing_clientcert`, `lambda_event_clientcert_malformed`.
+- **`client-certificate-auth/fetch` subpath** — `extractClientCertificateFromRequest(request, options)` extracts the client certificate from a Web standard `Request` (or any object whose `headers` iterates `[name, value]` tuples). Header-only by construction. Works in Hono, Next.js Route Handlers, SvelteKit hooks, Astro middleware, Remix loaders, Cloudflare Workers, `Bun.serve`, `Deno.serve`, and any other runtime that exposes a Web Request.
+
+### Types
+
+- `CertificateSource` union widened with the three new preset names (`aws-alb-verify`, `azure-app-service`, `cloudflare-rfc9440`).
+- `PresetConfig` gains an optional `chainHeader` field for two-header schemes.
+- `ClientCertificateAuthOptions` and `ExtractorOptions` gain an optional `chainHeader` field.
+- New exports `LambdaEventWithClientCert`, `LambdaClientCert`, `LambdaExtractionResult` from `client-certificate-auth/lambda`.
+- New export `RequestLike` from `client-certificate-auth/fetch`.
+
+### Tests
+
+- Added 23 unit tests across `test-unit-parsers.js` (new preset entries) and `test-unit-extractor.js` (per-preset E2E, chainHeader validation, chainHeader behavior, chain linking, malformed chain entries, override semantics).
+- Added 11 unit tests for the Lambda subpath in `test-unit-lambda.js` (v1 / v2 / both / missing fields / malformed PEM / null event).
+- Added 11 unit tests for the Fetch subpath in `test-unit-fetch.js` (per-preset extraction from a Web `Request`, plain header-iterable objects, `verifyHeader`/`verifyValue`, chain extraction, header-only guarantee).
+- Added TypeScript type tests covering the new preset names, `chainHeader` option, Lambda helper signature, and Fetch helper signature.
+
 ## [2.0.2] - 2026-05-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Comprehensive toolkit for client SSL certificate authentication (mTLS) in Node.j
 
 **Recommended by AWS** - Featured in the [AWS API Gateway documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-client-side-ssl-authentication.html#certificate-validation).
 
-**Fanatically Tested** - 100% line/branch/function/statement coverage, plus mutation testing and E2E tests against real nginx/Envoy/Traefik containers. ~5,224 lines of test code for ~788 lines of source (measured by [cloc](https://github.com/AlDanial/cloc)).
+**Fanatically Tested** - 100% line/branch/function/statement coverage, plus mutation testing and E2E tests against real nginx/Envoy/Traefik containers. ~6,207 lines of test code for ~937 lines of source (measured by [cloc](https://github.com/AlDanial/cloc)).
 
 ## Installation
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
         items: [
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Reverse Proxy Support', link: '/guide/reverse-proxy' },
+          { text: 'AWS Lambda', link: '/guide/lambda' },
+          { text: 'Fetch / Web Request', link: '/guide/fetch' },
           { text: 'WebSocket Support', link: '/guide/websocket' },
           { text: 'Authorization Helpers', link: '/guide/helpers' },
           { text: 'TypeScript & CJS', link: '/guide/typescript' },

--- a/docs/guide/fetch.md
+++ b/docs/guide/fetch.md
@@ -1,0 +1,169 @@
+# Fetch / Web Request
+
+When using a framework that exposes Web standard `Request` and `Response` (Hono, Next.js Route Handlers, SvelteKit `hooks.server.ts`, Astro middleware, Remix loaders, Cloudflare Workers, `Bun.serve`, `Deno.serve`), the Express-style `(req, res, next)` middleware signature does not apply. There is no Node `req.socket` and `request.headers` is a `Headers` map rather than a plain object.
+
+The `client-certificate-auth/fetch` subpath provides a small framework-agnostic adapter for this case.
+
+## Usage
+
+```javascript
+import { extractClientCertificateFromRequest } from 'client-certificate-auth/fetch';
+
+const result = extractClientCertificateFromRequest(request, {
+  certificateSource: 'cloudflare-rfc9440',
+});
+
+if (!result.success) {
+  // Reject with 401 or your framework's equivalent
+}
+```
+
+The helper returns the same `{ success, certificate, reason }` result as `extractClientCertificate()` from `client-certificate-auth/extractor`. Validation helpers from `client-certificate-auth/helpers` work without modification.
+
+## Header-Only
+
+Web `Request` does not expose the TLS socket, so the Fetch adapter is header-only. Configure a header source via `certificateSource` or `certificateHeader` + `headerEncoding`; `fallbackToSocket` has no effect.
+
+## Recipes
+
+### Hono
+
+```javascript
+import { Hono } from 'hono';
+import { extractClientCertificateFromRequest } from 'client-certificate-auth/fetch';
+
+const app = new Hono();
+
+app.get('/secure', (c) => {
+  const result = extractClientCertificateFromRequest(c.req.raw, {
+    certificateSource: 'cloudflare-rfc9440',
+  });
+  if (!result.success) return c.text('Unauthorized', 401);
+  return c.text(`Hello ${result.certificate.subject.CN}`);
+});
+
+export default app;
+```
+
+### Next.js Route Handler
+
+```javascript
+// app/api/secure/route.js
+import { extractClientCertificateFromRequest } from 'client-certificate-auth/fetch';
+
+export async function GET(request) {
+  const result = extractClientCertificateFromRequest(request, {
+    certificateSource: 'aws-alb',
+  });
+  if (!result.success) return new Response('Unauthorized', { status: 401 });
+  return Response.json({ user: result.certificate.subject.CN });
+}
+```
+
+### SvelteKit hooks.server.ts
+
+```typescript
+import type { Handle } from '@sveltejs/kit';
+import { extractClientCertificateFromRequest } from 'client-certificate-auth/fetch';
+
+export const handle: Handle = async ({ event, resolve }) => {
+  const result = extractClientCertificateFromRequest(event.request, {
+    certificateSource: 'cloudflare-rfc9440',
+  });
+  if (result.success) {
+    event.locals.user = { cn: result.certificate.subject.CN };
+  }
+  return resolve(event);
+};
+```
+
+### Astro middleware
+
+```typescript
+// src/middleware.ts
+import { defineMiddleware } from 'astro:middleware';
+import { extractClientCertificateFromRequest } from 'client-certificate-auth/fetch';
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const result = extractClientCertificateFromRequest(context.request, {
+    certificateSource: 'aws-alb',
+  });
+  if (!result.success) return new Response('Unauthorized', { status: 401 });
+  context.locals.user = { cn: result.certificate.subject.CN };
+  return next();
+});
+```
+
+### Cloudflare Workers
+
+```javascript
+import { extractClientCertificateFromRequest } from 'client-certificate-auth/fetch';
+
+export default {
+  async fetch(request, env) {
+    const result = extractClientCertificateFromRequest(request, {
+      certificateSource: 'cloudflare-rfc9440',
+    });
+    if (!result.success) return new Response('Unauthorized', { status: 401 });
+    return new Response(`Hello ${result.certificate.subject.CN}`);
+  },
+};
+```
+
+### Remix / React Router 7 loader
+
+```typescript
+import type { LoaderFunctionArgs } from 'react-router';
+import { extractClientCertificateFromRequest } from 'client-certificate-auth/fetch';
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const result = extractClientCertificateFromRequest(request, {
+    certificateSource: 'aws-alb',
+  });
+  if (!result.success) throw new Response('Unauthorized', { status: 401 });
+  return { user: { cn: result.certificate.subject.CN } };
+}
+```
+
+### Bun.serve
+
+```javascript
+import { extractClientCertificateFromRequest } from 'client-certificate-auth/fetch';
+
+Bun.serve({
+  port: 3000,
+  fetch(request) {
+    const result = extractClientCertificateFromRequest(request, {
+      certificateSource: 'cloudflare-rfc9440',
+    });
+    if (!result.success) return new Response('Unauthorized', { status: 401 });
+    return new Response(`Hello ${result.certificate.subject.CN}`);
+  },
+});
+```
+
+## Plain Header-Iterable Objects
+
+The adapter accepts any object whose `headers` field iterates as `[name, value]` tuples. A native `Headers` instance, a `Map`, or any custom equivalent works:
+
+```javascript
+const headers = new Map([['client-cert', ':base64DER:']]);
+const result = extractClientCertificateFromRequest({ headers }, {
+  certificateSource: 'cloudflare-rfc9440',
+});
+```
+
+This is useful for testing without constructing a full Web `Request`.
+
+## CommonJS
+
+```javascript
+const fetchAdapter = await require('client-certificate-auth/fetch').load();
+const result = fetchAdapter.extractClientCertificateFromRequest(request, {
+  certificateSource: 'aws-alb',
+});
+```
+
+## See Also
+
+- [Reverse proxy support](./reverse-proxy.md) for the supported presets and encodings, including the new `cloudflare-rfc9440` and the `chainHeader` option for RFC 9440 two-header schemes.

--- a/docs/guide/fetch.md
+++ b/docs/guide/fetch.md
@@ -24,6 +24,10 @@ The helper returns the same `{ success, certificate, reason }` result as `extrac
 
 Web `Request` does not expose the TLS socket, so the Fetch adapter is header-only. Configure a header source via `certificateSource` or `certificateHeader` + `headerEncoding`; `fallbackToSocket` has no effect.
 
+::: warning Runtime requirement
+The adapter imports the core extractor, which uses `node:crypto` (`X509Certificate`). Runtimes must provide Node-compatible crypto: Node, Bun, Deno, and Cloudflare Workers with `nodejs_compat` all work. Pure edge runtimes without Node compatibility will fail at import time.
+:::
+
 ## Recipes
 
 ### Hono

--- a/docs/guide/lambda.md
+++ b/docs/guide/lambda.md
@@ -32,10 +32,10 @@ API Gateway sends client certificate information at one of two paths depending o
 
 | API Type | Payload Format | Path |
 |----------|----------------|------|
-| HTTP API | v2.0 | `event.requestContext.authentication.clientCert` |
+| HTTP API | v2.0 (default) | `event.requestContext.authentication.clientCert` |
 | REST API | v1.0 | `event.requestContext.identity.clientCert` |
 
-The helper reads both paths; if both are present, v2.0 takes precedence.
+HTTP API defaults to v2.0 but can be configured for v1.0, in which case the cert path matches the REST API (`identity.clientCert`). The helper reads both paths; if both are present, v2.0 takes precedence.
 
 The `clientCert` object always contains:
 
@@ -45,7 +45,10 @@ The `clientCert` object always contains:
   subjectDN: string,
   issuerDN: string,
   serialNumber: string,
-  validity: { notBefore: string, notAfter: string }
+  validity: {
+    notBefore: string,     // OpenSSL-style, e.g. "May 28 12:30:02 2019 GMT"
+    notAfter: string
+  }
 }
 ```
 

--- a/docs/guide/lambda.md
+++ b/docs/guide/lambda.md
@@ -1,0 +1,74 @@
+# AWS Lambda
+
+When AWS API Gateway has mTLS enabled on a custom domain and a Lambda function is the integration target, the validated client certificate arrives **inside the Lambda event object**, not as an HTTP header. The Express middleware in this package handles the header-based and socket-based cases but cannot reach into a Lambda event directly.
+
+The `client-certificate-auth/lambda` subpath provides a small framework-agnostic helper for this case.
+
+## Usage
+
+```javascript
+import { extractClientCertificateFromLambdaEvent } from 'client-certificate-auth/lambda';
+
+export const handler = async (event) => {
+  const result = extractClientCertificateFromLambdaEvent(event);
+
+  if (!result.success) {
+    return { statusCode: 401, body: result.reason };
+  }
+
+  if (result.certificate.subject.CN !== 'authorized-client') {
+    return { statusCode: 403, body: 'Forbidden' };
+  }
+
+  return { statusCode: 200, body: 'OK' };
+};
+```
+
+The helper returns the same `{ success, certificate, reason }` result as `extractClientCertificate()` from `client-certificate-auth/extractor`. The returned `certificate` is a `PeerCertificate` matching Node's `getPeerCertificate()` output, so validation helpers from `client-certificate-auth/helpers` (`allowCN`, `allowOU`, `allOf`, etc.) work without modification.
+
+## Event Payload Formats
+
+API Gateway sends client certificate information at one of two paths depending on the API type and payload version:
+
+| API Type | Payload Format | Path |
+|----------|----------------|------|
+| HTTP API | v2.0 | `event.requestContext.authentication.clientCert` |
+| REST API | v1.0 | `event.requestContext.identity.clientCert` |
+
+The helper reads both paths; if both are present, v2.0 takes precedence.
+
+The `clientCert` object always contains:
+
+```typescript
+{
+  clientCertPem: string,   // PEM with BEGIN/END delimiters
+  subjectDN: string,
+  issuerDN: string,
+  serialNumber: string,
+  validity: { notBefore: string, notAfter: string }
+}
+```
+
+The helper parses `clientCertPem` into a `PeerCertificate` and returns it; the API-Gateway-parsed `subjectDN` / `issuerDN` / `serialNumber` / `validity` fields are not surfaced through this helper (use `result.certificate.subject`, `result.certificate.issuer`, etc.).
+
+## Rejection Reasons
+
+| Reason | Meaning |
+|--------|---------|
+| `lambda_event_missing_clientcert` | No `clientCertPem` at either the v2 or v1 path. Typical cause: mTLS not enabled on the API Gateway custom domain, or the client did not present a certificate. |
+| `lambda_event_clientcert_malformed` | `clientCertPem` was present but failed to parse as a PEM certificate. |
+
+## CommonJS
+
+```javascript
+const lambda = await require('client-certificate-auth/lambda').load();
+exports.handler = async (event) => {
+  const result = lambda.extractClientCertificateFromLambdaEvent(event);
+  // ...
+};
+```
+
+## See Also
+
+- [AWS API Gateway HTTP API mTLS documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-mutual-tls.html)
+- For AWS ALB mTLS, use the [`aws-alb` or `aws-alb-verify` preset](./reverse-proxy.md#preset-details) with the standard middleware instead. ALB forwards certificates as HTTP headers, not Lambda event fields.

--- a/docs/guide/reverse-proxy.md
+++ b/docs/guide/reverse-proxy.md
@@ -7,9 +7,19 @@ When your application runs behind a TLS-terminating reverse proxy, the client ce
 For common proxies, use the `certificateSource` option to automatically configure the correct header and encoding:
 
 ```javascript
-// AWS Application Load Balancer
+// AWS Application Load Balancer (mTLS passthrough)
 app.use(clientCertificateAuth(checkAuth, {
   certificateSource: 'aws-alb'
+}));
+
+// AWS Application Load Balancer (mTLS verify mode)
+app.use(clientCertificateAuth(checkAuth, {
+  certificateSource: 'aws-alb-verify'
+}));
+
+// Azure App Service
+app.use(clientCertificateAuth(checkAuth, {
+  certificateSource: 'azure-app-service'
 }));
 
 // Envoy / Istio
@@ -17,9 +27,14 @@ app.use(clientCertificateAuth(checkAuth, {
   certificateSource: 'envoy'
 }));
 
-// Cloudflare
+// Cloudflare (legacy Cf-Client-Cert-Der-Base64 header)
 app.use(clientCertificateAuth(checkAuth, {
   certificateSource: 'cloudflare'
+}));
+
+// Cloudflare (RFC 9440 Client-Cert / Client-Cert-Chain headers, March 2026+)
+app.use(clientCertificateAuth(checkAuth, {
+  certificateSource: 'cloudflare-rfc9440'
 }));
 
 // Traefik
@@ -32,11 +47,14 @@ app.use(clientCertificateAuth(checkAuth, {
 
 Each preset maps to a specific header name and encoding format:
 
-| Preset | Header | Encoding |
-|--------|--------|----------|
+| Preset | Header(s) | Encoding |
+|--------|-----------|----------|
 | `aws-alb` | `X-Amzn-Mtls-Clientcert` | URL-encoded PEM (AWS variant) |
-| `envoy` | `X-Forwarded-Client-Cert` | XFCC structured format |
+| `aws-alb-verify` | `X-Amzn-Mtls-Clientcert-Leaf` | URL-encoded PEM (AWS variant) |
+| `azure-app-service` | `X-ARR-ClientCert` | Base64-encoded DER |
 | `cloudflare` | `Cf-Client-Cert-Der-Base64` | Base64-encoded DER |
+| `cloudflare-rfc9440` | `Client-Cert` + `Client-Cert-Chain` | RFC 9440 |
+| `envoy` | `X-Forwarded-Client-Cert` | XFCC structured format |
 | `traefik` | `X-Forwarded-Tls-Client-Cert` | Base64-encoded DER \* |
 
 ::: tip Traefik note
@@ -45,6 +63,20 @@ The `traefik` preset targets Traefik v3's `PassTLSClientCert` middleware with `p
 
 ::: tip Cloudflare note
 Cloudflare also provides certificates via the `CF-Client-Cert-PEM` header (URL-encoded PEM). If you use that header instead, configure manually with `certificateHeader: 'CF-Client-Cert-PEM'` and `headerEncoding: 'url-pem'`.
+
+For the newer RFC 9440 forwarding feature (March 2026+), use the `cloudflare-rfc9440` preset, which pairs the standard `Client-Cert` header with the `Client-Cert-Chain` header via the new `chainHeader` option (see "Chain Header" below).
+:::
+
+::: tip Azure note
+The `azure-app-service` preset targets Azure App Service, which sends the bare base64-encoded DER (the body of a PEM cert with the BEGIN/END delimiters stripped) in `X-ARR-ClientCert`.
+
+Azure Application Gateway uses the same header name via a rewrite rule on the `{var_client_certificate}` server variable, but emits PEM (with BEGIN/END delimiters), not base64 DER. Azure API Management exposes client certificates through a policy/context model rather than a header. Both are deployment-specific; configure manually with the appropriate `certificateHeader` + `headerEncoding` combination, or open an issue if you want a dedicated preset.
+:::
+
+::: warning Azure App Service does not validate the client certificate
+App Service forwards whatever certificate the client presents during the TLS handshake. It does not check the certificate against a configured trust store. The middleware can parse the certificate out of the header, but your validation callback is responsible for full trust verification: matching the issuer against an expected CA, checking the validity window, checking revocation if applicable, and any application-level subject checks. A callback that only checks `cert.subject.CN` will accept any well-formed certificate any client cares to present.
+
+If you need ALB-style "the proxy already validated the cert" semantics on Azure, configure validation at the Application Gateway or API Management layer ahead of App Service, or run client cert validation in your application code against a trust store you control.
 :::
 
 ## Custom Headers
@@ -58,15 +90,21 @@ app.use(clientCertificateAuth(checkAuth, {
   headerEncoding: 'url-pem'
 }));
 
-// Google Cloud Load Balancer (RFC 9440)
+// Google Cloud Load Balancer (custom header populated from {client_cert_leaf}, RFC 9440)
 app.use(clientCertificateAuth(checkAuth, {
-  certificateHeader: 'X-SSL-Whatever-You-Use',
+  certificateHeader: 'X-Client-Cert-Leaf',
   headerEncoding: 'rfc9440'
 }));
 
 // HAProxy with base64 DER
 app.use(clientCertificateAuth(checkAuth, {
   certificateHeader: 'X-SSL-Whatever-You-Use',
+  headerEncoding: 'base64-der'
+}));
+
+// Caddy with the certificate_der_base64 placeholder
+app.use(clientCertificateAuth(checkAuth, {
+  certificateHeader: 'X-Client-Cert',
   headerEncoding: 'base64-der'
 }));
 ```
@@ -80,8 +118,32 @@ The library supports five encoding formats covering all major reverse proxies:
 | `url-pem` | URL-encoded PEM certificate | nginx, HAProxy |
 | `url-pem-aws` | URL-encoded PEM (AWS variant, `+` as safe char) | AWS ALB |
 | `xfcc` | Envoy's structured `Key=Value;...` format | Envoy, Istio |
-| `base64-der` | Base64-encoded DER certificate | Cloudflare, Traefik |
-| `rfc9440` | RFC 9440 format: `:base64-der:` | Google Cloud LB |
+| `base64-der` | Base64-encoded DER certificate | Cloudflare, Traefik, Azure App Service, Caddy |
+| `rfc9440` | RFC 9440 format: `:base64-der:` | Cloudflare (RFC 9440 forwarding), Google Cloud LB |
+
+## Chain Header
+
+Some proxies forward the leaf certificate and the certificate chain in two separate headers. RFC 9440 is the canonical example: the leaf goes in `Client-Cert` and the chain in `Client-Cert-Chain` (a comma-separated structured-field list of `:base64:` items, leaf-nearest first).
+
+The `chainHeader` option pairs a chain header with the configured leaf header. The chain header value is split on commas, each item is parsed with the same `headerEncoding`, and the resulting certificates are linked via `issuerCertificate` after the leaf. Set `includeChain: true` to keep the chain on the request object; otherwise the chain is parsed and dropped (matching the existing single-header chain stripping behavior).
+
+```javascript
+// Cloudflare RFC 9440 (chain header is configured automatically by the preset)
+app.use(clientCertificateAuth(checkAuth, {
+  certificateSource: 'cloudflare-rfc9440',
+  includeChain: true
+}));
+
+// Custom two-header scheme
+app.use(clientCertificateAuth(checkAuth, {
+  certificateHeader: 'X-Client-Cert',
+  chainHeader: 'X-Client-Cert-Chain',
+  headerEncoding: 'rfc9440',
+  includeChain: true
+}));
+```
+
+The comma splitting targets RFC 9440 structured-field lists. For non-RFC-9440 encodings that may contain commas inside a single cert value, use the single-header chain support already built into `base64-der` (comma-separated DER) and `url-pem-aws` (concatenated PEM blocks) instead.
 
 ## Fallback Mode
 

--- a/lib/clientCertificateAuth.cjs
+++ b/lib/clientCertificateAuth.cjs
@@ -39,6 +39,7 @@ function isThenable(value) {
 const UNSUPPORTED_OPTIONS = [
     'certificateSource',
     'certificateHeader',
+    'chainHeader',
     'headerEncoding',
     'fallbackToSocket',
     'verifyHeader',

--- a/lib/clientCertificateAuth.d.ts
+++ b/lib/clientCertificateAuth.d.ts
@@ -78,6 +78,15 @@ export interface ClientCertificateAuthOptions {
     certificateHeader?: string;
 
     /**
+     * Optional second header carrying the certificate chain alongside the leaf.
+     * Split on commas per RFC 9440, each item parsed with the same
+     * headerEncoding, results linked via issuerCertificate. For non-RFC-9440
+     * encodings the comma split may not match the encoding's list convention.
+     * Same trust boundary as certificateHeader.
+     */
+    chainHeader?: string;
+
+    /**
      * How to decode the header value.
      * Required when using certificateHeader without certificateSource.
      */

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -28,7 +28,7 @@ function isThenable(value) {
 
 /**
  * @typedef {Object} ClientCertificateAuthOptions
- * @property {'aws-alb' | 'envoy' | 'cloudflare' | 'traefik'} [certificateSource] - Use a preset
+ * @property {'aws-alb' | 'aws-alb-verify' | 'azure-app-service' | 'cloudflare' | 'cloudflare-rfc9440' | 'envoy' | 'traefik'} [certificateSource] - Use a preset
  *   configuration for a known reverse proxy. Header-based certs are only checked if this or
  *   certificateHeader is set. Trust boundary: the proxy must strip the preset's header from
  *   external requests; any source that can set it is trusted to assert client identity.
@@ -36,7 +36,11 @@ function isThenable(value) {
  *   Overrides preset header name if also using certificateSource. Trust boundary: the proxy
  *   must strip this header from external requests; any source that can set it is trusted to
  *   assert client identity.
- * @property {'url-pem' | 'url-pem-aws' | 'xfcc' | 'base64-der' | 'rfc9440'} [headerEncoding] - 
+ * @property {string} [chainHeader] - Optional second header carrying the certificate chain
+ *   alongside the leaf in certificateHeader (or the preset's header). Split on commas per
+ *   RFC 9440, each item parsed with the same headerEncoding, results linked via
+ *   issuerCertificate. Same trust boundary as certificateHeader.
+ * @property {'url-pem' | 'url-pem-aws' | 'xfcc' | 'base64-der' | 'rfc9440'} [headerEncoding] -
  *   How to decode the header value. Required when using certificateHeader without certificateSource.
  * @property {boolean} [fallbackToSocket=false] - If header-based extraction is configured but 
  *   fails (header absent or malformed), try socket.getPeerCertificate() instead of returning 401.
@@ -96,6 +100,7 @@ export default function clientCertificateAuth(callback, options = {}) {
   const {
     certificateSource,
     certificateHeader,
+    chainHeader,
     headerEncoding,
     fallbackToSocket = false,
     includeChain = false,
@@ -132,6 +137,7 @@ export default function clientCertificateAuth(callback, options = {}) {
     const result = extractClientCertificate(req, {
       certificateSource,
       certificateHeader,
+      chainHeader,
       headerEncoding,
       fallbackToSocket,
       includeChain,

--- a/lib/extractor.d.ts
+++ b/lib/extractor.d.ts
@@ -12,8 +12,9 @@
  */
 /**
  * @typedef {Object} ExtractorOptions
- * @property {'aws-alb' | 'envoy' | 'cloudflare' | 'traefik'} [certificateSource] - Preset configuration
+ * @property {'aws-alb' | 'aws-alb-verify' | 'azure-app-service' | 'cloudflare' | 'cloudflare-rfc9440' | 'envoy' | 'traefik'} [certificateSource] - Preset configuration
  * @property {string} [certificateHeader] - Custom header name
+ * @property {string} [chainHeader] - Optional second header carrying the certificate chain
  * @property {'url-pem' | 'url-pem-aws' | 'xfcc' | 'base64-der' | 'rfc9440'} [headerEncoding] - Header encoding
  * @property {boolean} [fallbackToSocket=false] - Try socket if header extraction fails
  * @property {boolean} [includeChain=false] - Include issuerCertificate chain
@@ -89,11 +90,15 @@ export type ExtractorOptions = {
     /**
      * - Preset configuration
      */
-    certificateSource?: "aws-alb" | "envoy" | "cloudflare" | "traefik";
+    certificateSource?: "aws-alb" | "aws-alb-verify" | "azure-app-service" | "cloudflare" | "cloudflare-rfc9440" | "envoy" | "traefik";
     /**
      * - Custom header name
      */
     certificateHeader?: string;
+    /**
+     * - Optional second header carrying the certificate chain
+     */
+    chainHeader?: string;
     /**
      * - Header encoding
      */

--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -4,22 +4,23 @@
  * @license MIT
  */
 
-import { getCertificateFromHeaders, PRESETS } from './parsers.js';
+import { getCertificateFromHeaders, parseHeaderValue, PRESETS } from './parsers.js';
 
 const VALID_ENCODINGS = ['url-pem', 'url-pem-aws', 'xfcc', 'base64-der', 'rfc9440'];
 
 /**
  * Validate options shared by `extractClientCertificate` and the middleware
  * constructor. Throws on misconfiguration (unknown preset, unknown encoding,
- * `certificateHeader` without an encoding source, or only one of
- * `verifyHeader`/`verifyValue`). Omitted or `undefined` options are treated
- * as the empty object; explicit `null` will throw a `TypeError`.
+ * `certificateHeader` without an encoding source, `chainHeader` without a
+ * leaf header source, or only one of `verifyHeader`/`verifyValue`). Omitted
+ * or `undefined` options are treated as the empty object; explicit `null`
+ * will throw a `TypeError`.
  *
  * @param {ExtractorOptions} [options]
  * @throws {Error} when options are malformed
  */
 export function validateExtractorOptions(options = {}) {
-  const { certificateSource, certificateHeader, headerEncoding, verifyHeader, verifyValue } = options;
+  const { certificateSource, certificateHeader, chainHeader, headerEncoding, verifyHeader, verifyValue } = options;
 
   if ((verifyHeader && !verifyValue) || (!verifyHeader && verifyValue)) {
     throw new Error(
@@ -44,6 +45,12 @@ export function validateExtractorOptions(options = {}) {
       'client-certificate-auth: certificateHeader requires headerEncoding (or a certificateSource preset that supplies one)'
     );
   }
+
+  if (chainHeader && !certificateSource && !certificateHeader) {
+    throw new Error(
+      'client-certificate-auth: chainHeader requires certificateSource or certificateHeader (chain header must accompany a leaf header configuration)'
+    );
+  }
 }
 
 /**
@@ -61,12 +68,16 @@ export function validateExtractorOptions(options = {}) {
 
 /**
  * @typedef {Object} ExtractorOptions
- * @property {'aws-alb' | 'envoy' | 'cloudflare' | 'traefik'} [certificateSource] - Preset
+ * @property {'aws-alb' | 'aws-alb-verify' | 'azure-app-service' | 'cloudflare' | 'cloudflare-rfc9440' | 'envoy' | 'traefik'} [certificateSource] - Preset
  *   configuration. Trust boundary: the proxy must strip the preset's header from external
  *   requests; any source that can set it is trusted to assert client identity.
  * @property {string} [certificateHeader] - Custom header name. Trust boundary: the proxy must
  *   strip this header from external requests; any source that can set it is trusted to assert
  *   client identity.
+ * @property {string} [chainHeader] - Optional second header carrying the certificate chain
+ *   alongside the leaf. Split on commas per RFC 9440, each item parsed with the same
+ *   `headerEncoding`, results linked via `issuerCertificate`. For non-RFC-9440 encodings
+ *   the comma split may not match the encoding's list convention.
  * @property {'url-pem' | 'url-pem-aws' | 'xfcc' | 'base64-der' | 'rfc9440'} [headerEncoding] - Header encoding
  * @property {boolean} [fallbackToSocket=false] - Try socket if header extraction fails
  * @property {boolean} [includeChain=false] - Include issuerCertificate chain
@@ -111,6 +122,7 @@ export function extractClientCertificate(req, options = {}) {
   const {
     certificateSource,
     certificateHeader,
+    chainHeader,
     headerEncoding,
     fallbackToSocket = false,
     includeChain = false,
@@ -141,6 +153,32 @@ export function extractClientCertificate(req, options = {}) {
       certificateHeader,
       headerEncoding,
     });
+
+    // Append chain from a separate chain header if configured.
+    // Resolve: explicit chainHeader > preset.chainHeader; explicit encoding > preset.encoding.
+    // Split on commas per RFC 9440, parse each item, link via issuerCertificate.
+    if (cert) {
+      const preset = certificateSource ? PRESETS[certificateSource] : null;
+      const chainHeaderName = (chainHeader ?? preset?.chainHeader)?.toLowerCase();
+      const chainEncoding = headerEncoding ?? preset?.encoding;
+      if (chainHeaderName && chainEncoding) {
+        const chainHeaderValue = req.headers[chainHeaderName];
+        if (chainHeaderValue && !Array.isArray(chainHeaderValue)) {
+          const chainCerts = chainHeaderValue
+            .split(',')
+            .map(item => item.trim())
+            .filter(Boolean)
+            .map(item => parseHeaderValue(item, chainEncoding))
+            .filter(Boolean);
+          if (chainCerts.length > 0) {
+            cert.issuerCertificate = chainCerts[0];
+            for (let i = 0; i < chainCerts.length - 1; i++) {
+              chainCerts[i].issuerCertificate = chainCerts[i + 1];
+            }
+          }
+        }
+      }
+    }
 
     // Normalize: strip chain unless includeChain is true
     if (cert && !includeChain && 'issuerCertificate' in cert) {

--- a/lib/fetch.cjs
+++ b/lib/fetch.cjs
@@ -1,0 +1,20 @@
+/*!
+ * client-certificate-auth/fetch - CommonJS wrapper
+ * Copyright (C) 2013-2026 Tony Gies
+ * @license MIT
+ */
+
+'use strict';
+
+let _module;
+
+async function load() {
+    // Stryker disable next-line ConditionalExpression,BlockStatement: test ordering caches _module from prior test; ConditionalExpression→true (always re-import) re-imports same module successfully; BlockStatement→{} uses cached value
+    if (!_module) {
+        // Stryker disable next-line StringLiteral: test ordering caches _module; StringLiteral→"" fails import but cached value masks it
+        _module = await import('./fetch.js');
+    }
+    return _module;
+}
+
+module.exports = { load };

--- a/lib/fetch.d.cts
+++ b/lib/fetch.d.cts
@@ -1,0 +1,13 @@
+/*!
+ * client-certificate-auth/fetch - CommonJS type declarations
+ * Copyright (C) 2013-2026 Tony Gies
+ * @license MIT
+ */
+
+import type * as FetchModule from './fetch.js';
+
+declare const fetchAdapter: {
+    load(): Promise<typeof FetchModule>;
+};
+
+export = fetchAdapter;

--- a/lib/fetch.d.ts
+++ b/lib/fetch.d.ts
@@ -1,0 +1,28 @@
+/*!
+ * client-certificate-auth/fetch - TypeScript declarations
+ * Copyright (C) 2013-2026 Tony Gies
+ * @license MIT
+ */
+
+import type { ExtractorOptions, ExtractionResult } from './extractor.js';
+
+/**
+ * Any object whose `headers` field iterates as `[name, value]` tuples.
+ * Web `Request`, undici `Headers`, Bun, Deno, and Node 18+ `Headers`
+ * all work without modification.
+ */
+export interface RequestLike {
+    headers: Iterable<[string, string]>;
+}
+
+/**
+ * Extract a client certificate from a Web standard `Request` or any
+ * object with iterable headers. Header-only (no TLS socket in Web Request).
+ *
+ * @param request - A Web Request or any object with iterable headers
+ * @param options - Same options as `extractClientCertificate`. Header options only.
+ */
+export declare function extractClientCertificateFromRequest(
+    request: RequestLike,
+    options?: ExtractorOptions
+): ExtractionResult;

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,5 +1,5 @@
 /*!
- * client-certificate-auth/fetch - Web Request adapter for fetch-shaped runtimes
+ * client-certificate-auth/fetch - Web Request adapter
  * Copyright (C) 2013-2026 Tony Gies
  * @license MIT
  */
@@ -15,18 +15,9 @@ import { extractClientCertificate } from './extractor.js';
  * Extract a client certificate from a Web standard `Request` (or any object
  * with an iterable `headers` field that yields `[name, value]` tuples).
  *
- * This adapter exists for fetch-shaped runtimes where there is no Node
- * `req.socket` and `request.headers` is a `Headers` map rather than a plain
- * object. It converts the headers via `Object.fromEntries(request.headers)`
- * and calls the core `extractClientCertificate` in header-only mode.
- *
- * Header-only by construction: the Web `Request` abstraction has no TLS
- * socket. Socket-based extraction is impossible through this entry point;
- * configure a header source via `certificateSource` or `certificateHeader`.
- *
- * Works in Hono, Next.js Route Handlers, SvelteKit hooks, Astro middleware,
- * Remix loaders, Cloudflare Workers, `Bun.serve`, `Deno.serve`, and any other
- * runtime that exposes a Web Request.
+ * Normalizes header names to lowercase and delegates to the core
+ * `extractClientCertificate`. Header-only: Web `Request` has no TLS socket,
+ * so `fallbackToSocket` is stripped and has no effect.
  *
  * @param {{ headers: Iterable<[string, string]> }} request - A Web Request or any object whose `headers` iterates `[name, value]` pairs.
  * @param {ExtractorOptions} [options={}] - Same options as `extractClientCertificate`. Header-extraction options only; socket options are ignored.
@@ -55,8 +46,15 @@ import { extractClientCertificate } from './extractor.js';
  * }
  */
 export function extractClientCertificateFromRequest(request, options = {}) {
-  return extractClientCertificate(
-    { headers: Object.fromEntries(request.headers) },
-    options
-  );
+  // Web Headers normalizes to lowercase, but Map and other iterables
+  // preserve casing. Normalize here for the core extractor's lowercase lookup.
+  const headers = {};
+  for (const [name, value] of request.headers) {
+    headers[name.toLowerCase()] = value;
+  }
+
+  // Stryker disable next-line ObjectLiteral: destructure-discard strips fallbackToSocket
+  const { fallbackToSocket: _ignored, ...rest } = options;
+
+  return extractClientCertificate({ headers }, rest);
 }

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,0 +1,62 @@
+/*!
+ * client-certificate-auth/fetch - Web Request adapter for fetch-shaped runtimes
+ * Copyright (C) 2013-2026 Tony Gies
+ * @license MIT
+ */
+
+import { extractClientCertificate } from './extractor.js';
+
+/**
+ * @typedef {import('./extractor.js').ExtractorOptions} ExtractorOptions
+ * @typedef {import('./extractor.js').ExtractionResult} ExtractionResult
+ */
+
+/**
+ * Extract a client certificate from a Web standard `Request` (or any object
+ * with an iterable `headers` field that yields `[name, value]` tuples).
+ *
+ * This adapter exists for fetch-shaped runtimes where there is no Node
+ * `req.socket` and `request.headers` is a `Headers` map rather than a plain
+ * object. It converts the headers via `Object.fromEntries(request.headers)`
+ * and calls the core `extractClientCertificate` in header-only mode.
+ *
+ * Header-only by construction: the Web `Request` abstraction has no TLS
+ * socket. Socket-based extraction is impossible through this entry point;
+ * configure a header source via `certificateSource` or `certificateHeader`.
+ *
+ * Works in Hono, Next.js Route Handlers, SvelteKit hooks, Astro middleware,
+ * Remix loaders, Cloudflare Workers, `Bun.serve`, `Deno.serve`, and any other
+ * runtime that exposes a Web Request.
+ *
+ * @param {{ headers: Iterable<[string, string]> }} request - A Web Request or any object whose `headers` iterates `[name, value]` pairs.
+ * @param {ExtractorOptions} [options={}] - Same options as `extractClientCertificate`. Header-extraction options only; socket options are ignored.
+ * @returns {ExtractionResult}
+ *
+ * @example
+ * // Hono
+ * import { extractClientCertificateFromRequest } from 'client-certificate-auth/fetch';
+ *
+ * app.get('/secure', async (c) => {
+ *   const result = extractClientCertificateFromRequest(c.req.raw, {
+ *     certificateSource: 'cloudflare-rfc9440',
+ *   });
+ *   if (!result.success) return c.text('Unauthorized', 401);
+ *   return c.text(`Hello ${result.certificate.subject.CN}`);
+ * });
+ *
+ * @example
+ * // Next.js Route Handler
+ * export async function GET(request) {
+ *   const result = extractClientCertificateFromRequest(request, {
+ *     certificateSource: 'aws-alb',
+ *   });
+ *   if (!result.success) return new Response('Unauthorized', { status: 401 });
+ *   return Response.json({ user: result.certificate.subject.CN });
+ * }
+ */
+export function extractClientCertificateFromRequest(request, options = {}) {
+  return extractClientCertificate(
+    { headers: Object.fromEntries(request.headers) },
+    options
+  );
+}

--- a/lib/lambda.cjs
+++ b/lib/lambda.cjs
@@ -1,0 +1,20 @@
+/*!
+ * client-certificate-auth/lambda - CommonJS wrapper
+ * Copyright (C) 2013-2026 Tony Gies
+ * @license MIT
+ */
+
+'use strict';
+
+let _module;
+
+async function load() {
+    // Stryker disable next-line ConditionalExpression,BlockStatement: test ordering caches _module from prior test; ConditionalExpression→true (always re-import) re-imports same module successfully; BlockStatement→{} uses cached value
+    if (!_module) {
+        // Stryker disable next-line StringLiteral: test ordering caches _module; StringLiteral→"" fails import but cached value masks it
+        _module = await import('./lambda.js');
+    }
+    return _module;
+}
+
+module.exports = { load };

--- a/lib/lambda.d.cts
+++ b/lib/lambda.d.cts
@@ -1,0 +1,13 @@
+/*!
+ * client-certificate-auth/lambda - CommonJS type declarations
+ * Copyright (C) 2013-2026 Tony Gies
+ * @license MIT
+ */
+
+import type * as LambdaModule from './lambda.js';
+
+declare const lambda: {
+    load(): Promise<typeof LambdaModule>;
+};
+
+export = lambda;

--- a/lib/lambda.d.ts
+++ b/lib/lambda.d.ts
@@ -1,0 +1,75 @@
+/*!
+ * client-certificate-auth/lambda - TypeScript declarations
+ * Copyright (C) 2013-2026 Tony Gies
+ * @license MIT
+ */
+
+import type { PeerCertificate } from 'tls';
+
+/**
+ * Client certificate object from the API Gateway Lambda event.
+ * Common to v1 and v2 payload formats. Compatible with `@types/aws-lambda`
+ * without requiring it as a dependency.
+ */
+export interface LambdaClientCert {
+    /** PEM-encoded client certificate with BEGIN/END delimiters. */
+    clientCertPem: string;
+    /** Optional subject distinguished name string, parsed by API Gateway. */
+    subjectDN?: string;
+    /** Optional issuer distinguished name string, parsed by API Gateway. */
+    issuerDN?: string;
+    /** Optional certificate serial number string, parsed by API Gateway. */
+    serialNumber?: string;
+    /** Optional validity window parsed by API Gateway. */
+    validity?: {
+        notBefore?: string;
+        notAfter?: string;
+    };
+}
+
+/**
+ * Lambda event subset declaring only the cert-bearing paths.
+ * Accepts HTTP API (v2.0) and REST API (v1.0) payload formats.
+ */
+export interface LambdaEventWithClientCert {
+    requestContext?: {
+        /** v2.0 payload format: HTTP API. */
+        authentication?: {
+            clientCert?: LambdaClientCert;
+        };
+        /** v1.0 payload format: REST API. */
+        identity?: {
+            clientCert?: LambdaClientCert;
+        };
+    };
+}
+
+/**
+ * Result returned by `extractClientCertificateFromLambdaEvent`.
+ * Matches the core extractor's `ExtractionResult`.
+ */
+export interface LambdaExtractionResult {
+    /** Whether extraction succeeded. */
+    success: boolean;
+    /** Extracted certificate (null on failure). */
+    certificate: PeerCertificate | null;
+    /**
+     * Rejection reason code (null on success). Lambda-specific reasons:
+     * - 'lambda_event_missing_clientcert'
+     * - 'lambda_event_clientcert_malformed'
+     */
+    reason: string | null;
+}
+
+/**
+ * Extract a client certificate from an AWS API Gateway Lambda event. Handles
+ * both v2.0 payload format (`event.requestContext.authentication.clientCert`)
+ * and v1.0 payload format (`event.requestContext.identity.clientCert`).
+ *
+ * @param event - The Lambda event from API Gateway
+ *
+ * @see https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-mutual-tls.html
+ */
+export declare function extractClientCertificateFromLambdaEvent(
+    event: LambdaEventWithClientCert
+): LambdaExtractionResult;

--- a/lib/lambda.d.ts
+++ b/lib/lambda.d.ts
@@ -66,10 +66,13 @@ export interface LambdaExtractionResult {
  * both v2.0 payload format (`event.requestContext.authentication.clientCert`)
  * and v1.0 payload format (`event.requestContext.identity.clientCert`).
  *
- * @param event - The Lambda event from API Gateway
+ * Also accepts `null` and `undefined`, returning
+ * `lambda_event_missing_clientcert`.
+ *
+ * @param event - The Lambda event from API Gateway, or null/undefined
  *
  * @see https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-mutual-tls.html
  */
 export declare function extractClientCertificateFromLambdaEvent(
-    event: LambdaEventWithClientCert
+    event: LambdaEventWithClientCert | null | undefined
 ): LambdaExtractionResult;

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -25,7 +25,7 @@ import { pemToCertificate } from './parsers.js';
  * works inside a Lambda handler. If both v1 and v2 fields are present,
  * v2 takes precedence.
  *
- * @param {object} event - The Lambda event object from API Gateway
+ * @param {object | null | undefined} event - The Lambda event object from API Gateway (also accepts null/undefined)
  * @returns {ExtractionResult}
  *
  * Rejection reasons:

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -1,0 +1,73 @@
+/*!
+ * client-certificate-auth/lambda - AWS Lambda event adapter
+ * Copyright (C) 2013-2026 Tony Gies
+ * @license MIT
+ */
+
+import { pemToCertificate } from './parsers.js';
+
+/**
+ * @typedef {import('./extractor.js').ExtractionResult} ExtractionResult
+ */
+
+/**
+ * Extract a client certificate from an AWS API Gateway Lambda event.
+ *
+ * API Gateway HTTP API (v2.0 payload) delivers the validated mTLS client
+ * certificate as a pre-parsed object at
+ * `event.requestContext.authentication.clientCert`. The legacy REST API
+ * (v1.0 payload) delivers it at `event.requestContext.identity.clientCert`.
+ * Both payloads carry a `clientCertPem` field plus parsed `subjectDN`,
+ * `issuerDN`, `serialNumber`, and `validity` fields.
+ *
+ * Parses `clientCertPem` into a `PeerCertificate` so the same validation
+ * logic used with `getPeerCertificate()` or `extractClientCertificate()`
+ * works inside a Lambda handler. If both v1 and v2 fields are present,
+ * v2 takes precedence.
+ *
+ * @param {object} event - The Lambda event object from API Gateway
+ * @returns {ExtractionResult}
+ *
+ * Rejection reasons:
+ * - 'lambda_event_missing_clientcert' - No clientCertPem at either v1 or v2 location
+ * - 'lambda_event_clientcert_malformed' - clientCertPem present but parsing failed
+ *
+ * @example
+ * import { extractClientCertificateFromLambdaEvent } from 'client-certificate-auth/lambda';
+ *
+ * export const handler = async (event) => {
+ *   const result = extractClientCertificateFromLambdaEvent(event);
+ *   if (!result.success) return { statusCode: 401, body: result.reason };
+ *   if (result.certificate.subject.CN !== 'authorized-client') {
+ *     return { statusCode: 403 };
+ *   }
+ *   return { statusCode: 200, body: 'OK' };
+ * };
+ */
+export function extractClientCertificateFromLambdaEvent(event) {
+  const v2 = event?.requestContext?.authentication?.clientCert;
+  const v1 = event?.requestContext?.identity?.clientCert;
+  const clientCert = v2 ?? v1;
+
+  if (!clientCert?.clientCertPem) {
+    return {
+      success: false,
+      certificate: null,
+      reason: 'lambda_event_missing_clientcert',
+    };
+  }
+
+  try {
+    return {
+      success: true,
+      certificate: pemToCertificate(clientCert.clientCertPem),
+      reason: null,
+    };
+  } catch {
+    return {
+      success: false,
+      certificate: null,
+      reason: 'lambda_event_clientcert_malformed',
+    };
+  }
+}

--- a/lib/parsers.d.ts
+++ b/lib/parsers.d.ts
@@ -14,7 +14,14 @@ export type HeaderEncoding = 'url-pem' | 'url-pem-aws' | 'xfcc' | 'base64-der' |
 /**
  * Supported certificate source presets.
  */
-export type CertificateSource = 'aws-alb' | 'envoy' | 'cloudflare' | 'traefik';
+export type CertificateSource =
+    | 'aws-alb'
+    | 'aws-alb-verify'
+    | 'azure-app-service'
+    | 'cloudflare'
+    | 'cloudflare-rfc9440'
+    | 'envoy'
+    | 'traefik';
 
 /**
  * Preset configuration for a reverse proxy.
@@ -22,6 +29,12 @@ export type CertificateSource = 'aws-alb' | 'envoy' | 'cloudflare' | 'traefik';
 export interface PresetConfig {
     /** HTTP header name (lowercase) */
     header: string;
+    /**
+     * Optional second header carrying the certificate chain. Set on
+     * two-header schemes like RFC 9440 (Client-Cert + Client-Cert-Chain).
+     * Lowercased per Node convention.
+     */
+    chainHeader?: string;
     /** Encoding format used by this proxy */
     encoding: HeaderEncoding;
 }

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -13,7 +13,8 @@ import { X509Certificate } from 'node:crypto';
 
 /**
  * Preset configurations for common reverse proxies.
- * Maps preset name to { header, encoding } configuration.
+ * Maps preset name to { header, encoding } configuration, with optional
+ * `chainHeader` for two-header schemes (RFC 9440).
  */
 export const PRESETS = {
     /**
@@ -25,20 +26,54 @@ export const PRESETS = {
         encoding: 'url-pem-aws',
     },
     /**
+     * AWS Application Load Balancer in mTLS verify mode. ALB validates the
+     * client certificate against a configured trust store and forwards the
+     * leaf as URL-encoded PEM (the leaf only, not the chain) plus parsed
+     * subject/issuer/serial/validity headers for convenience.
+     * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/mutual-authentication.html
+     */
+    'aws-alb-verify': {
+        header: 'x-amzn-mtls-clientcert-leaf',
+        encoding: 'url-pem-aws',
+    },
+    /**
+     * Azure App Service mTLS forwarding. App Service injects the bare
+     * base64-encoded DER (the body of a PEM cert without delimiters) into
+     * `X-ARR-ClientCert`. Same header convention is used by IIS/ARR.
+     * @see https://learn.microsoft.com/en-us/azure/app-service/app-service-web-configure-tls-mutual-auth
+     */
+    'azure-app-service': {
+        header: 'x-arr-clientcert',
+        encoding: 'base64-der',
+    },
+    /**
+     * Cloudflare with client_certificate_forwarding enabled (legacy
+     * Cf-Client-Cert-* header family).
+     * @see https://developers.cloudflare.com/api-shield/security/mtls/configure/
+     */
+    'cloudflare': {
+        header: 'cf-client-cert-der-base64',
+        encoding: 'base64-der',
+    },
+    /**
+     * Cloudflare with RFC 9440 forwarding enabled (March 2026 feature).
+     * Operators set `Client-Cert` and `Client-Cert-Chain` headers via
+     * Transform Rules. Leaf is `:base64:`-wrapped; chain is a structured
+     * field list of `:base64:` items separated by commas.
+     * @see https://developers.cloudflare.com/changelog/post/2026-03-25-rfc9440-mtls-fields/
+     */
+    'cloudflare-rfc9440': {
+        header: 'client-cert',
+        chainHeader: 'client-cert-chain',
+        encoding: 'rfc9440',
+    },
+    /**
      * Envoy proxy / Istio service mesh using XFCC header.
      * @see https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert
      */
     'envoy': {
         header: 'x-forwarded-client-cert',
         encoding: 'xfcc',
-    },
-    /**
-     * Cloudflare with client_certificate_forwarding enabled.
-     * @see https://developers.cloudflare.com/api-shield/security/mtls/configure/
-     */
-    'cloudflare': {
-        header: 'cf-client-cert-der-base64',
-        encoding: 'base64-der',
     },
     /**
      * Traefik with PassTLSClientCert middleware (pem: true).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client-certificate-auth",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client-certificate-auth",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",
@@ -198,6 +198,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3862,6 +3863,7 @@
       "integrity": "sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@inquirer/prompts": "^8.0.0",
         "@stryker-mutator/api": "9.6.1",
@@ -4155,6 +4157,7 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -4791,6 +4794,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5177,6 +5181,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5884,6 +5889,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -6277,6 +6283,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6669,6 +6676,7 @@
       "integrity": "sha512-T65crff26CKV2CZ3csg5y05r+560srp0b8EbAif35euW58hzklVf/Gb4Q+/HCtB8e9III3QFEyk5BWV5XJuOyw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -8885,6 +8893,7 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -10898,6 +10907,7 @@
       "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
@@ -10935,6 +10945,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11197,6 +11208,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11319,6 +11331,7 @@
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-certificate-auth",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Express/Connect middleware for mTLS client certificate authentication with reverse proxy support (AWS ALB, Envoy, Cloudflare, Traefik)",
   "homepage": "https://github.com/tgies/client-certificate-auth",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,26 @@
         "types": "./lib/extractor.d.cts",
         "default": "./lib/extractor.cjs"
       }
+    },
+    "./lambda": {
+      "import": {
+        "types": "./lib/lambda.d.ts",
+        "default": "./lib/lambda.js"
+      },
+      "require": {
+        "types": "./lib/lambda.d.cts",
+        "default": "./lib/lambda.cjs"
+      }
+    },
+    "./fetch": {
+      "import": {
+        "types": "./lib/fetch.d.ts",
+        "default": "./lib/fetch.js"
+      },
+      "require": {
+        "types": "./lib/fetch.d.cts",
+        "default": "./lib/fetch.cjs"
+      }
     }
   },
   "main": "./lib/clientCertificateAuth.cjs",
@@ -65,6 +85,12 @@
       ],
       "extractor": [
         "./lib/extractor.d.ts"
+      ],
+      "lambda": [
+        "./lib/lambda.d.ts"
+      ],
+      "fetch": [
+        "./lib/fetch.d.ts"
       ]
     }
   },

--- a/test/test-typescript-types.ts
+++ b/test/test-typescript-types.ts
@@ -27,6 +27,7 @@ const _asyncMiddleware = clientCertificateAuth(async (cert) => {
 const options: ClientCertificateAuthOptions = {
     certificateSource: 'aws-alb',
     certificateHeader: 'X-SSL-Client-Cert',
+    chainHeader: 'X-SSL-Client-Cert-Chain',
     headerEncoding: 'url-pem',
     fallbackToSocket: true,
     includeChain: true,
@@ -34,6 +35,13 @@ const options: ClientCertificateAuthOptions = {
     verifyValue: 'SUCCESS',
 };
 const _withOptions = clientCertificateAuth(() => true, options);
+
+// Test 5a: All shipped preset names are accepted by certificateSource
+const _awsAlbVerify = clientCertificateAuth(() => true, { certificateSource: 'aws-alb-verify' });
+const _azureAppService = clientCertificateAuth(() => true, { certificateSource: 'azure-app-service' });
+const _cloudflareRfc9440 = clientCertificateAuth(() => true, { certificateSource: 'cloudflare-rfc9440' });
+const _envoy = clientCertificateAuth(() => true, { certificateSource: 'envoy' });
+const _traefik = clientCertificateAuth(() => true, { certificateSource: 'traefik' });
 
 // Test 6: ClientCertRequest has clientCertificate property
 function checkRequest(req: ClientCertRequest): void {
@@ -172,6 +180,86 @@ async function testExpressIntegrationCjsLoad() {
     app.use(cjs((cert) => cert.subject.CN === 'admin'));
 }
 
+// Test 20: Lambda subpath - extractClientCertificateFromLambdaEvent
+import { extractClientCertificateFromLambdaEvent } from '../lib/lambda.js';
+import type { LambdaEventWithClientCert, LambdaExtractionResult } from '../lib/lambda.js';
+function testLambdaExtractor() {
+    const event: LambdaEventWithClientCert = {
+        requestContext: {
+            authentication: {
+                clientCert: { clientCertPem: '-----BEGIN CERTIFICATE-----...' },
+            },
+        },
+    };
+    const result: LambdaExtractionResult = extractClientCertificateFromLambdaEvent(event);
+    if (result.success) {
+        const _cn: string | string[] | undefined = result.certificate?.subject?.CN;
+        void _cn;
+    } else {
+        const _reason: string | null = result.reason;
+        void _reason;
+    }
+}
+
+// Test 21: Lambda CJS load() returns the lambda module
+import type cjsLambda from '../lib/lambda.cjs';
+async function testCjsLambdaLoad() {
+    const lambda = await (null as unknown as typeof cjsLambda).load();
+    const _r = lambda.extractClientCertificateFromLambdaEvent({
+        requestContext: { authentication: { clientCert: { clientCertPem: '...' } } },
+    });
+    void _r;
+}
+
+// Test 22: Fetch subpath - extractClientCertificateFromRequest accepts a Web Request
+import { extractClientCertificateFromRequest } from '../lib/fetch.js';
+import type { RequestLike } from '../lib/fetch.js';
+function testFetchExtractor() {
+    const request = new Request('https://example.com', {
+        headers: { 'Client-Cert': ':base64:' },
+    });
+    const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'cloudflare-rfc9440',
+        includeChain: true,
+    });
+    if (result.success) {
+        const _cn: string | string[] | undefined = result.certificate?.subject?.CN;
+        void _cn;
+    }
+}
+
+// Test 22a: Fetch subpath also accepts any iterable-headers object
+function testFetchExtractorPlainObject() {
+    const headers: RequestLike['headers'] = new Map([['client-cert', ':base64:']]);
+    const _r = extractClientCertificateFromRequest({ headers }, {
+        certificateSource: 'cloudflare-rfc9440',
+    });
+    void _r;
+}
+
+// Test 23: Fetch CJS load() returns the fetch module
+import type cjsFetch from '../lib/fetch.cjs';
+async function testCjsFetchLoad() {
+    const fetchAdapter = await (null as unknown as typeof cjsFetch).load();
+    const request = new Request('https://example.com', { headers: {} });
+    const _r = fetchAdapter.extractClientCertificateFromRequest(request, {
+        certificateSource: 'aws-alb',
+    });
+    void _r;
+}
+
+// Test 24: chainHeader option is typed as optional string
+const _chainHeaderOption = clientCertificateAuth(() => true, {
+    certificateSource: 'cloudflare-rfc9440',
+    chainHeader: 'X-Custom-Chain',
+});
+
+// Test 25: Negative - invalid preset name still rejected after the new presets land
+const _badNewSource = clientCertificateAuth(() => true, {
+    // @ts-expect-error - 'azure-application-gateway' is not (yet) a valid CertificateSource
+    certificateSource: 'azure-application-gateway',
+});
+
 // Suppress unused variable warnings - this file is for type-checking only
 void _statusCode;
 void _syncMiddleware;
@@ -191,3 +279,15 @@ void testCjsExtractorLoad;
 void testExpressIntegration;
 void testExpressIntegrationCjsSync;
 void testExpressIntegrationCjsLoad;
+void _awsAlbVerify;
+void _azureAppService;
+void _cloudflareRfc9440;
+void _envoy;
+void _traefik;
+void testLambdaExtractor;
+void testCjsLambdaLoad;
+void testFetchExtractor;
+void testFetchExtractorPlainObject;
+void testCjsFetchLoad;
+void _chainHeaderOption;
+void _badNewSource;

--- a/test/test-unit-extractor.js
+++ b/test/test-unit-extractor.js
@@ -1,5 +1,23 @@
 import assert from 'node:assert/strict';
 import { extractClientCertificate, validateExtractorOptions } from '../lib/extractor.js';
+import { pemToDer } from './test-helpers.js';
+
+/**
+ * Encode a DER-encoded certificate as RFC 9440 single-cert header value:
+ * `:base64:`. Cloudflare and other RFC 9440 implementations emit this on
+ * the Client-Cert header.
+ */
+function encodeAsRfc9440(derBuffer) {
+  return ':' + derBuffer.toString('base64') + ':';
+}
+
+/**
+ * Encode a list of DER buffers as RFC 9440 structured-field list of
+ * `:base64:` items, comma-separated. Used for Client-Cert-Chain.
+ */
+function encodeAsRfc9440List(derBuffers) {
+  return derBuffers.map(encodeAsRfc9440).join(', ');
+}
 
 // Mock certificate for socket tests
 const getMockPeerCertificate = () => ({
@@ -116,6 +134,35 @@ describe('extractClientCertificate', () => {
       assert.throws(
         () => extractClientCertificate(req, { certificateHeader: 'X-Cert' }),
         { name: 'Error', message: /certificateHeader requires headerEncoding/ }
+      );
+    });
+
+    it('should throw when chainHeader is set without a leaf header source', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      assert.throws(
+        () => extractClientCertificate(req, { chainHeader: 'X-Cert-Chain' }),
+        { name: 'Error', message: /chainHeader requires certificateSource or certificateHeader/ }
+      );
+    });
+
+    it('should not throw when chainHeader is paired with certificateHeader and headerEncoding', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      assert.doesNotThrow(() =>
+        extractClientCertificate(req, {
+          certificateHeader: 'X-Cert',
+          chainHeader: 'X-Cert-Chain',
+          headerEncoding: 'rfc9440',
+        })
+      );
+    });
+
+    it('should not throw when chainHeader is paired with certificateSource', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      assert.doesNotThrow(() =>
+        extractClientCertificate(req, {
+          certificateSource: 'cloudflare-rfc9440',
+          chainHeader: 'X-Custom-Chain',
+        })
       );
     });
 
@@ -360,6 +407,335 @@ describe('extractClientCertificate', () => {
         // Should fail due to invalid cert, but shows header was checked
         assert.strictEqual(result.success, false);
         assert.strictEqual(result.reason, 'header_missing_or_malformed');
+      });
+    });
+
+    describe('AWS ALB verify preset', () => {
+      it('should extract certificate from x-amzn-mtls-clientcert-leaf header', () => {
+        const encodedCert = encodeURIComponent(testPem);
+        const req = {
+          headers: {
+            'x-amzn-mtls-clientcert-leaf': encodedCert,
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'aws-alb-verify',
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.strictEqual(result.certificate.subject.CN, 'client.example.com');
+      });
+
+      it('should not read x-amzn-mtls-clientcert (passthrough header) when in verify preset', () => {
+        const encodedCert = encodeURIComponent(testPem);
+        const req = {
+          headers: {
+            'x-amzn-mtls-clientcert': encodedCert,
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'aws-alb-verify',
+        });
+
+        assert.strictEqual(result.success, false);
+        assert.strictEqual(result.reason, 'header_missing_or_malformed');
+      });
+    });
+
+    describe('Azure App Service preset', () => {
+      it('should extract certificate from x-arr-clientcert header (base64 DER)', () => {
+        // Azure App Service forwards bare base64-encoded DER (the body of a
+        // PEM cert without the BEGIN/END delimiters). The base64-der parser
+        // accepts that directly.
+        const derBuffer = pemToDer(testPem);
+        const headerValue = derBuffer.toString('base64');
+        const req = {
+          headers: {
+            'x-arr-clientcert': headerValue,
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'azure-app-service',
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.strictEqual(result.certificate.subject.CN, 'client.example.com');
+      });
+
+      it('should return error when x-arr-clientcert is missing', () => {
+        const req = {
+          headers: {},
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'azure-app-service',
+        });
+
+        assert.strictEqual(result.success, false);
+        assert.strictEqual(result.reason, 'header_missing_or_malformed');
+      });
+    });
+
+    describe('Cloudflare RFC 9440 preset', () => {
+      it('should extract certificate from Client-Cert header (RFC 9440)', () => {
+        const derBuffer = pemToDer(testPem);
+        const req = {
+          headers: {
+            'client-cert': encodeAsRfc9440(derBuffer),
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'cloudflare-rfc9440',
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.strictEqual(result.certificate.subject.CN, 'client.example.com');
+      });
+
+      it('should link chain from Client-Cert-Chain header when includeChain is true', async () => {
+        const selfsigned = (await import('selfsigned')).default;
+        const intermediate = await selfsigned.generate(
+          [{ name: 'commonName', value: 'Intermediate CA' }],
+          { algorithm: 'sha256', keySize: 2048, days: 1 }
+        );
+        const root = await selfsigned.generate(
+          [{ name: 'commonName', value: 'Root CA' }],
+          { algorithm: 'sha256', keySize: 2048, days: 1 }
+        );
+
+        const leafDer = pemToDer(testPem);
+        const intermediateDer = pemToDer(intermediate.cert);
+        const rootDer = pemToDer(root.cert);
+
+        const req = {
+          headers: {
+            'client-cert': encodeAsRfc9440(leafDer),
+            'client-cert-chain': encodeAsRfc9440List([intermediateDer, rootDer]),
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'cloudflare-rfc9440',
+          includeChain: true,
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.strictEqual(result.certificate.subject.CN, 'client.example.com');
+        assert.ok(result.certificate.issuerCertificate);
+        assert.strictEqual(result.certificate.issuerCertificate.subject.CN, 'Intermediate CA');
+        assert.ok(result.certificate.issuerCertificate.issuerCertificate);
+        assert.strictEqual(
+          result.certificate.issuerCertificate.issuerCertificate.subject.CN,
+          'Root CA'
+        );
+      });
+
+      it('should strip chain by default when includeChain is false', async () => {
+        const selfsigned = (await import('selfsigned')).default;
+        const intermediate = await selfsigned.generate(
+          [{ name: 'commonName', value: 'Intermediate CA' }],
+          { algorithm: 'sha256', keySize: 2048, days: 1 }
+        );
+
+        const leafDer = pemToDer(testPem);
+        const intermediateDer = pemToDer(intermediate.cert);
+
+        const req = {
+          headers: {
+            'client-cert': encodeAsRfc9440(leafDer),
+            'client-cert-chain': encodeAsRfc9440List([intermediateDer]),
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'cloudflare-rfc9440',
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.strictEqual(result.certificate.issuerCertificate, undefined);
+      });
+
+      it('should succeed with leaf only when chain header is absent', () => {
+        const derBuffer = pemToDer(testPem);
+        const req = {
+          headers: {
+            'client-cert': encodeAsRfc9440(derBuffer),
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'cloudflare-rfc9440',
+          includeChain: true,
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.strictEqual(result.certificate.subject.CN, 'client.example.com');
+        assert.strictEqual(result.certificate.issuerCertificate, undefined);
+      });
+
+      it('should leave issuerCertificate unset when every chain entry fails to parse', () => {
+        const leafDer = pemToDer(testPem);
+
+        const req = {
+          headers: {
+            'client-cert': encodeAsRfc9440(leafDer),
+            'client-cert-chain': ':not_base64:, :also_garbage:',
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'cloudflare-rfc9440',
+          includeChain: true,
+        });
+
+        // Leaf still parses; chain is empty after filtering parse failures.
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.strictEqual(result.certificate.issuerCertificate, undefined);
+      });
+
+      it('should drop malformed chain entries and link the survivors', async () => {
+        const selfsigned = (await import('selfsigned')).default;
+        const intermediate = await selfsigned.generate(
+          [{ name: 'commonName', value: 'Intermediate CA' }],
+          { algorithm: 'sha256', keySize: 2048, days: 1 }
+        );
+
+        const leafDer = pemToDer(testPem);
+        const intermediateDer = pemToDer(intermediate.cert);
+
+        const chainValue = [
+          ':not_base64:',
+          encodeAsRfc9440(intermediateDer),
+          ':also_garbage:',
+        ].join(', ');
+
+        const req = {
+          headers: {
+            'client-cert': encodeAsRfc9440(leafDer),
+            'client-cert-chain': chainValue,
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'cloudflare-rfc9440',
+          includeChain: true,
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.ok(result.certificate.issuerCertificate);
+        assert.strictEqual(result.certificate.issuerCertificate.subject.CN, 'Intermediate CA');
+        assert.strictEqual(result.certificate.issuerCertificate.issuerCertificate, undefined);
+      });
+    });
+
+    describe('chainHeader option (explicit)', () => {
+      it('should link chain when using custom certificateHeader + chainHeader', async () => {
+        const selfsigned = (await import('selfsigned')).default;
+        const intermediate = await selfsigned.generate(
+          [{ name: 'commonName', value: 'Intermediate CA' }],
+          { algorithm: 'sha256', keySize: 2048, days: 1 }
+        );
+
+        const leafDer = pemToDer(testPem);
+        const intermediateDer = pemToDer(intermediate.cert);
+
+        const req = {
+          headers: {
+            'x-leaf-cert': encodeAsRfc9440(leafDer),
+            'x-chain-cert': encodeAsRfc9440List([intermediateDer]),
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateHeader: 'X-Leaf-Cert',
+          chainHeader: 'X-Chain-Cert',
+          headerEncoding: 'rfc9440',
+          includeChain: true,
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.ok(result.certificate.issuerCertificate);
+        assert.strictEqual(result.certificate.issuerCertificate.subject.CN, 'Intermediate CA');
+      });
+
+      it('should override preset chainHeader when explicit chainHeader is provided', async () => {
+        const selfsigned = (await import('selfsigned')).default;
+        const intermediate = await selfsigned.generate(
+          [{ name: 'commonName', value: 'Override Intermediate CA' }],
+          { algorithm: 'sha256', keySize: 2048, days: 1 }
+        );
+
+        const leafDer = pemToDer(testPem);
+        const intermediateDer = pemToDer(intermediate.cert);
+
+        const req = {
+          headers: {
+            'client-cert': encodeAsRfc9440(leafDer),
+            'x-custom-chain': encodeAsRfc9440List([intermediateDer]),
+            // The preset's default `client-cert-chain` is absent on purpose.
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'cloudflare-rfc9440',
+          chainHeader: 'X-Custom-Chain',
+          includeChain: true,
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.ok(result.certificate.issuerCertificate);
+        assert.strictEqual(
+          result.certificate.issuerCertificate.subject.CN,
+          'Override Intermediate CA'
+        );
+      });
+
+      it('should ignore chain header when its value is an array (duplicate headers)', async () => {
+        const leafDer = pemToDer(testPem);
+
+        const req = {
+          headers: {
+            'client-cert': encodeAsRfc9440(leafDer),
+            'client-cert-chain': ['header1', 'header2'],
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'cloudflare-rfc9440',
+          includeChain: true,
+        });
+
+        // Leaf still parses; chain is silently dropped.
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.strictEqual(result.certificate.issuerCertificate, undefined);
       });
     });
 

--- a/test/test-unit-fetch.cjs
+++ b/test/test-unit-fetch.cjs
@@ -1,0 +1,58 @@
+/*!
+ * client-certificate-auth/fetch - CommonJS unit tests
+ */
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fetchAdapter = require('../lib/fetch.cjs');
+
+describe('fetch (CommonJS wrapper)', () => {
+    it('should expose only a load() function', () => {
+        const keys = Object.keys(fetchAdapter);
+        assert.deepEqual(keys, ['load']);
+        assert.equal(typeof fetchAdapter.load, 'function');
+    });
+
+    it('should return cached module on subsequent calls', async () => {
+        const first = await fetchAdapter.load();
+        const second = await fetchAdapter.load();
+        assert.strictEqual(first, second);
+    });
+
+    it('should export the extractClientCertificateFromRequest function', async () => {
+        const mod = await fetchAdapter.load();
+        assert.equal(
+            typeof mod.extractClientCertificateFromRequest,
+            'function',
+            'extractClientCertificateFromRequest should be a function'
+        );
+    });
+
+    it('should extract a certificate from a Web Request', async () => {
+        const selfsigned = require('selfsigned');
+        const testCert = await selfsigned.generate(
+            [{ name: 'commonName', value: 'CJS Fetch Test' }],
+            { algorithm: 'sha256', keySize: 2048, days: 1 }
+        );
+
+        // Convert PEM body (no delimiters) to base64 DER, then to Azure App
+        // Service shape: bare base64-DER carried in X-ARR-ClientCert.
+        const base64Der = testCert.cert
+            .split('\n')
+            .filter(line => !line.startsWith('-----'))
+            .join('');
+
+        const { extractClientCertificateFromRequest } = await fetchAdapter.load();
+        const request = new Request('https://example.com', {
+            headers: { 'X-ARR-ClientCert': base64Der },
+        });
+
+        const result = extractClientCertificateFromRequest(request, {
+            certificateSource: 'azure-app-service',
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.certificate.subject.CN, 'CJS Fetch Test');
+    });
+});

--- a/test/test-unit-fetch.js
+++ b/test/test-unit-fetch.js
@@ -1,0 +1,226 @@
+import assert from 'node:assert/strict';
+import { extractClientCertificateFromRequest } from '../lib/fetch.js';
+import { generateClientCertificate, pemToDer } from './test-helpers.js';
+
+/**
+ * Encode a DER buffer as RFC 9440 single-cert header value: `:base64:`.
+ */
+function encodeAsRfc9440(derBuffer) {
+  return ':' + derBuffer.toString('base64') + ':';
+}
+
+describe('extractClientCertificateFromRequest', () => {
+  let testPem;
+  let testDer;
+
+  beforeAll(async () => {
+    const testCert = await generateClientCertificate('fetch.example.com');
+    testPem = testCert.cert;
+    testDer = pemToDer(testPem);
+  });
+
+  describe('default options', () => {
+    it('should accept a request without an options argument', () => {
+      const request = new Request('https://example.com/api', {
+        headers: {},
+      });
+      const result = extractClientCertificateFromRequest(request);
+
+      // No headers configured, no socket: the extractor falls through to the
+      // socket path and reports `socket_not_authorized` since the synthetic
+      // req object has no socket field.
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'socket_not_authorized');
+    });
+  });
+
+  describe('with Web Request', () => {
+    it('should extract certificate via cloudflare-rfc9440 preset from a Web Request', () => {
+      const request = new Request('https://example.com/api', {
+        headers: { 'Client-Cert': encodeAsRfc9440(testDer) },
+      });
+
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'cloudflare-rfc9440',
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.ok(result.certificate);
+      assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
+    });
+
+    it('should extract certificate via azure-app-service preset from a Web Request', () => {
+      const request = new Request('https://example.com/api', {
+        headers: { 'X-ARR-ClientCert': testDer.toString('base64') },
+      });
+
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'azure-app-service',
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.ok(result.certificate);
+      assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
+    });
+
+    it('should extract certificate via aws-alb preset from a Web Request', () => {
+      const request = new Request('https://example.com/api', {
+        headers: { 'X-Amzn-Mtls-Clientcert': encodeURIComponent(testPem) },
+      });
+
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'aws-alb',
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.ok(result.certificate);
+      assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
+    });
+
+    it('should return error when configured header is missing from the Request', () => {
+      const request = new Request('https://example.com/api', {
+        headers: { 'X-Other-Header': 'unrelated' },
+      });
+
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'cloudflare-rfc9440',
+      });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'header_missing_or_malformed');
+    });
+
+    it('should return error when configured header carries malformed data', () => {
+      const request = new Request('https://example.com/api', {
+        headers: { 'Client-Cert': 'not-a-real-cert' },
+      });
+
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'cloudflare-rfc9440',
+      });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'header_missing_or_malformed');
+    });
+  });
+
+  describe('verifyHeader / verifyValue', () => {
+    it('should accept the request when verifyHeader matches verifyValue', () => {
+      const request = new Request('https://example.com/api', {
+        headers: {
+          'Client-Cert': encodeAsRfc9440(testDer),
+          'X-SSL-Verify': 'SUCCESS',
+        },
+      });
+
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'cloudflare-rfc9440',
+        verifyHeader: 'X-SSL-Verify',
+        verifyValue: 'SUCCESS',
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
+    });
+
+    it('should reject the request when verifyHeader does not match verifyValue', () => {
+      const request = new Request('https://example.com/api', {
+        headers: {
+          'Client-Cert': encodeAsRfc9440(testDer),
+          'X-SSL-Verify': 'FAILED:cert_expired',
+        },
+      });
+
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'cloudflare-rfc9440',
+        verifyHeader: 'X-SSL-Verify',
+        verifyValue: 'SUCCESS',
+      });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'verification_header_mismatch');
+    });
+  });
+
+  describe('chain extraction', () => {
+    it('should link Client-Cert-Chain when present and includeChain is true', async () => {
+      const selfsigned = (await import('selfsigned')).default;
+      const intermediate = await selfsigned.generate(
+        [{ name: 'commonName', value: 'Fetch Intermediate CA' }],
+        { algorithm: 'sha256', keySize: 2048, days: 1 }
+      );
+      const intermediateDer = pemToDer(intermediate.cert);
+
+      const request = new Request('https://example.com/api', {
+        headers: {
+          'Client-Cert': encodeAsRfc9440(testDer),
+          'Client-Cert-Chain': encodeAsRfc9440(intermediateDer),
+        },
+      });
+
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'cloudflare-rfc9440',
+        includeChain: true,
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.ok(result.certificate.issuerCertificate);
+      assert.strictEqual(
+        result.certificate.issuerCertificate.subject.CN,
+        'Fetch Intermediate CA'
+      );
+    });
+  });
+
+  describe('with plain header-iterable object (non-Request)', () => {
+    it('should accept a plain object whose headers field iterates [name, value] tuples', () => {
+      // Map iterates as [key, value] tuples directly. The adapter only
+      // requires Object.fromEntries(request.headers) to produce a plain
+      // headers object - any iterable of pairs works.
+      const headers = new Map([
+        ['client-cert', encodeAsRfc9440(testDer)],
+      ]);
+
+      const result = extractClientCertificateFromRequest({ headers }, {
+        certificateSource: 'cloudflare-rfc9440',
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
+    });
+
+    it('should accept a Headers instance built without a Request', () => {
+      const headers = new Headers();
+      headers.set('client-cert', encodeAsRfc9440(testDer));
+
+      const result = extractClientCertificateFromRequest({ headers }, {
+        certificateSource: 'cloudflare-rfc9440',
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
+    });
+  });
+
+  describe('header-only by construction', () => {
+    it('should never access a socket field even if one is present on the request', () => {
+      // The adapter should not consult any socket field. We pass a socket
+      // that would throw if read, then confirm extraction works header-only.
+      const headers = new Headers();
+      headers.set('client-cert', encodeAsRfc9440(testDer));
+
+      const trap = new Proxy({}, {
+        get() {
+          throw new Error('socket was unexpectedly accessed by the fetch adapter');
+        },
+      });
+
+      const result = extractClientCertificateFromRequest(
+        { headers, socket: trap },
+        { certificateSource: 'cloudflare-rfc9440' }
+      );
+
+      assert.strictEqual(result.success, true);
+    });
+  });
+});

--- a/test/test-unit-fetch.js
+++ b/test/test-unit-fetch.js
@@ -32,6 +32,21 @@ describe('extractClientCertificateFromRequest', () => {
       assert.strictEqual(result.success, false);
       assert.strictEqual(result.reason, 'socket_not_authorized');
     });
+
+    it('should strip fallbackToSocket so missing headers report header_missing_or_malformed', () => {
+      // fallbackToSocket is stripped; there is no socket to fall back to.
+      const request = new Request('https://example.com/api', {
+        headers: { 'X-Other-Header': 'unrelated' },
+      });
+
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'cloudflare-rfc9440',
+        fallbackToSocket: true,
+      });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'header_missing_or_malformed');
+    });
   });
 
   describe('with Web Request', () => {
@@ -174,9 +189,6 @@ describe('extractClientCertificateFromRequest', () => {
 
   describe('with plain header-iterable object (non-Request)', () => {
     it('should accept a plain object whose headers field iterates [name, value] tuples', () => {
-      // Map iterates as [key, value] tuples directly. The adapter only
-      // requires Object.fromEntries(request.headers) to produce a plain
-      // headers object - any iterable of pairs works.
       const headers = new Map([
         ['client-cert', encodeAsRfc9440(testDer)],
       ]);
@@ -200,12 +212,24 @@ describe('extractClientCertificateFromRequest', () => {
       assert.strictEqual(result.success, true);
       assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
     });
+
+    it('should normalize header names to lowercase for the RequestLike Map path', () => {
+      // Map preserves casing; mixed-case keys need lowercasing.
+      const headers = new Map([
+        ['X-ARR-ClientCert', testDer.toString('base64')],
+      ]);
+
+      const result = extractClientCertificateFromRequest({ headers }, {
+        certificateSource: 'azure-app-service',
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
+    });
   });
 
-  describe('header-only by construction', () => {
+  describe('header-only behavior', () => {
     it('should never access a socket field even if one is present on the request', () => {
-      // The adapter should not consult any socket field. We pass a socket
-      // that would throw if read, then confirm extraction works header-only.
       const headers = new Headers();
       headers.set('client-cert', encodeAsRfc9440(testDer));
 

--- a/test/test-unit-lambda.cjs
+++ b/test/test-unit-lambda.cjs
@@ -1,0 +1,58 @@
+/*!
+ * client-certificate-auth/lambda - CommonJS unit tests
+ */
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const lambda = require('../lib/lambda.cjs');
+
+describe('lambda (CommonJS wrapper)', () => {
+    it('should expose only a load() function', () => {
+        const keys = Object.keys(lambda);
+        assert.deepEqual(keys, ['load']);
+        assert.equal(typeof lambda.load, 'function');
+    });
+
+    it('should return cached module on subsequent calls', async () => {
+        const first = await lambda.load();
+        const second = await lambda.load();
+        assert.strictEqual(first, second);
+    });
+
+    it('should export the extractClientCertificateFromLambdaEvent function', async () => {
+        const mod = await lambda.load();
+        assert.equal(
+            typeof mod.extractClientCertificateFromLambdaEvent,
+            'function',
+            'extractClientCertificateFromLambdaEvent should be a function'
+        );
+    });
+
+    it('should extract a certificate from a v2.0 API Gateway event', async () => {
+        const selfsigned = require('selfsigned');
+        const testCert = await selfsigned.generate(
+            [{ name: 'commonName', value: 'CJS Lambda Test' }],
+            { algorithm: 'sha256', keySize: 2048, days: 1 }
+        );
+
+        const { extractClientCertificateFromLambdaEvent } = await lambda.load();
+        const result = extractClientCertificateFromLambdaEvent({
+            requestContext: {
+                authentication: {
+                    clientCert: { clientCertPem: testCert.cert },
+                },
+            },
+        });
+
+        assert.equal(result.success, true);
+        assert.equal(result.certificate.subject.CN, 'CJS Lambda Test');
+    });
+
+    it('should report lambda_event_missing_clientcert when no cert is in the event', async () => {
+        const { extractClientCertificateFromLambdaEvent } = await lambda.load();
+        const result = extractClientCertificateFromLambdaEvent({});
+        assert.equal(result.success, false);
+        assert.equal(result.reason, 'lambda_event_missing_clientcert');
+    });
+});

--- a/test/test-unit-lambda.js
+++ b/test/test-unit-lambda.js
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { extractClientCertificateFromLambdaEvent } from '../lib/lambda.js';
+import { generateClientCertificate } from './test-helpers.js';
+
+describe('extractClientCertificateFromLambdaEvent', () => {
+  let testPem;
+
+  beforeAll(async () => {
+    const testCert = await generateClientCertificate('lambda.example.com');
+    testPem = testCert.cert;
+  });
+
+  describe('v2 payload (HTTP API)', () => {
+    it('should extract certificate from event.requestContext.authentication.clientCert', () => {
+      const event = {
+        requestContext: {
+          authentication: {
+            clientCert: {
+              clientCertPem: testPem,
+              subjectDN: 'CN=lambda.example.com',
+              issuerDN: 'CN=lambda.example.com',
+              serialNumber: '01',
+              validity: { notBefore: '...', notAfter: '...' },
+            },
+          },
+        },
+      };
+
+      const result = extractClientCertificateFromLambdaEvent(event);
+
+      assert.strictEqual(result.success, true);
+      assert.ok(result.certificate);
+      assert.strictEqual(result.certificate.subject.CN, 'lambda.example.com');
+      assert.strictEqual(result.reason, null);
+    });
+  });
+
+  describe('v1 payload (REST API)', () => {
+    it('should extract certificate from event.requestContext.identity.clientCert', () => {
+      const event = {
+        requestContext: {
+          identity: {
+            clientCert: {
+              clientCertPem: testPem,
+            },
+          },
+        },
+      };
+
+      const result = extractClientCertificateFromLambdaEvent(event);
+
+      assert.strictEqual(result.success, true);
+      assert.ok(result.certificate);
+      assert.strictEqual(result.certificate.subject.CN, 'lambda.example.com');
+      assert.strictEqual(result.reason, null);
+    });
+  });
+
+  describe('v2 takes precedence over v1', () => {
+    it('should prefer v2 path when both v1 and v2 client certs are present', async () => {
+      const v1Cert = await generateClientCertificate('v1.example.com');
+      const v2Cert = await generateClientCertificate('v2.example.com');
+
+      const event = {
+        requestContext: {
+          authentication: {
+            clientCert: { clientCertPem: v2Cert.cert },
+          },
+          identity: {
+            clientCert: { clientCertPem: v1Cert.cert },
+          },
+        },
+      };
+
+      const result = extractClientCertificateFromLambdaEvent(event);
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.certificate.subject.CN, 'v2.example.com');
+    });
+  });
+
+  describe('missing fields', () => {
+    it('should return error reason when requestContext is missing', () => {
+      const result = extractClientCertificateFromLambdaEvent({});
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.certificate, null);
+      assert.strictEqual(result.reason, 'lambda_event_missing_clientcert');
+    });
+
+    it('should return error reason when authentication and identity are both absent', () => {
+      const result = extractClientCertificateFromLambdaEvent({
+        requestContext: {},
+      });
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'lambda_event_missing_clientcert');
+    });
+
+    it('should return error reason when clientCert is missing under authentication', () => {
+      const result = extractClientCertificateFromLambdaEvent({
+        requestContext: { authentication: {} },
+      });
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'lambda_event_missing_clientcert');
+    });
+
+    it('should return error reason when clientCert is missing under identity', () => {
+      const result = extractClientCertificateFromLambdaEvent({
+        requestContext: { identity: {} },
+      });
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'lambda_event_missing_clientcert');
+    });
+
+    it('should return error reason when clientCertPem field is missing', () => {
+      const result = extractClientCertificateFromLambdaEvent({
+        requestContext: {
+          authentication: {
+            clientCert: { subjectDN: 'CN=somebody' },
+          },
+        },
+      });
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'lambda_event_missing_clientcert');
+    });
+
+    it('should accept null event without throwing', () => {
+      const result = extractClientCertificateFromLambdaEvent(null);
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'lambda_event_missing_clientcert');
+    });
+
+    it('should accept undefined event without throwing', () => {
+      const result = extractClientCertificateFromLambdaEvent(undefined);
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'lambda_event_missing_clientcert');
+    });
+  });
+
+  describe('malformed clientCertPem', () => {
+    it('should return malformed reason when clientCertPem is not parseable', () => {
+      const event = {
+        requestContext: {
+          authentication: {
+            clientCert: { clientCertPem: 'not a real pem certificate' },
+          },
+        },
+      };
+
+      const result = extractClientCertificateFromLambdaEvent(event);
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.certificate, null);
+      assert.strictEqual(result.reason, 'lambda_event_clientcert_malformed');
+    });
+
+    it('should return malformed reason for empty string clientCertPem', () => {
+      const event = {
+        requestContext: {
+          authentication: {
+            clientCert: { clientCertPem: '' },
+          },
+        },
+      };
+
+      const result = extractClientCertificateFromLambdaEvent(event);
+
+      // Empty string is falsy, treated as missing (not malformed).
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'lambda_event_missing_clientcert');
+    });
+  });
+});

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -94,6 +94,20 @@ describe('parsers module', () => {
             assert.equal(PRESETS['aws-alb'].encoding, 'url-pem-aws');
         });
 
+        it('should have aws-alb-verify preset', () => {
+            assert.ok(PRESETS['aws-alb-verify']);
+            assert.equal(PRESETS['aws-alb-verify'].header, 'x-amzn-mtls-clientcert-leaf');
+            assert.equal(PRESETS['aws-alb-verify'].encoding, 'url-pem-aws');
+            assert.equal(PRESETS['aws-alb-verify'].chainHeader, undefined);
+        });
+
+        it('should have azure-app-service preset', () => {
+            assert.ok(PRESETS['azure-app-service']);
+            assert.equal(PRESETS['azure-app-service'].header, 'x-arr-clientcert');
+            assert.equal(PRESETS['azure-app-service'].encoding, 'base64-der');
+            assert.equal(PRESETS['azure-app-service'].chainHeader, undefined);
+        });
+
         it('should have envoy preset', () => {
             assert.ok(PRESETS['envoy']);
             assert.equal(PRESETS['envoy'].header, 'x-forwarded-client-cert');
@@ -104,6 +118,13 @@ describe('parsers module', () => {
             assert.ok(PRESETS['cloudflare']);
             assert.equal(PRESETS['cloudflare'].header, 'cf-client-cert-der-base64');
             assert.equal(PRESETS['cloudflare'].encoding, 'base64-der');
+        });
+
+        it('should have cloudflare-rfc9440 preset', () => {
+            assert.ok(PRESETS['cloudflare-rfc9440']);
+            assert.equal(PRESETS['cloudflare-rfc9440'].header, 'client-cert');
+            assert.equal(PRESETS['cloudflare-rfc9440'].chainHeader, 'client-cert-chain');
+            assert.equal(PRESETS['cloudflare-rfc9440'].encoding, 'rfc9440');
         });
 
         it('should have traefik preset', () => {

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,9 +1,18 @@
 {
   "extends": "./tsconfig.json",
   "include": [
+    "lib/**/*.js",
     "lib/**/*.d.ts"
   ],
   "exclude": [
     "node_modules"
+  ],
+  "files": [
+    "lib/clientCertificateAuth.js",
+    "lib/helpers.js",
+    "lib/parsers.js",
+    "lib/extractor.js",
+    "lib/lambda.js",
+    "lib/fetch.js"
   ]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,12 +1,15 @@
 {
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": [
-    "lib/clientCertificateAuth.d.ts",
-    "lib/helpers.d.ts",
-    "lib/parsers.d.ts",
-    "lib/extractor.d.ts"
+    "lib/clientCertificateAuth.js",
+    "lib/helpers.js",
+    "lib/parsers.js",
+    "lib/extractor.js",
+    "lib/lambda.js",
+    "lib/fetch.js"
   ],
   "tsconfig": "tsconfig.typedoc.json",
+  "skipErrorChecking": true,
   "plugin": ["typedoc-plugin-markdown"],
   "out": "docs/api",
   "excludePrivate": true,


### PR DESCRIPTION
- Three new proxy presets: `aws-alb-verify` (ALB mTLS verify mode), `azure-app-service` (X-ARR-ClientCert), `cloudflare-rfc9440` (Cloudflare new RFC 9440).
- New `chainHeader` extractor option for RFC 9440-style two-header schemes (leaf + chain).
- New `client-certificate-auth/lambda` subpath: `extractClientCertificateFromLambdaEvent` for AWS API Gateway v1/v2 events.
- New `client-certificate-auth/fetch` subpath: `extractClientCertificateFromRequest` for Web Request runtimes (Hono, Next.js, SvelteKit, Astro, Remix, Cloudflare Workers, Bun, Deno).
- Reverse-proxy guide updated for the new presets and `chainHeader`.
- TypeDoc source links point at `.js` instead of `.d.ts` (fixes #81).