### PR TITLE
fix(auth): wrap non-Error callback throws/rejections before next()

### DIFF
--- a/lib/clientCertificateAuth.cjs
+++ b/lib/clientCertificateAuth.cjs
@@ -33,6 +33,19 @@ function isThenable(value) {
 }
 
 /**
+ * Wrap primitive values thrown or rejected by the validation callback in an
+ * Error so `.message` and `.status` access is safe; objects pass through.
+ * @param {unknown} err
+ * @returns {any}
+ */
+function normalizeCallbackError(err) {
+    if (err !== null && (typeof err === 'object' || typeof err === 'function')) {
+        return err;
+    }
+    return new Error(err === null || err === undefined ? '' : String(err));
+}
+
+/**
  * Options not supported by the sync CJS wrapper.
  * These require the ESM module's async header parsing.
  */
@@ -132,7 +145,8 @@ function clientCertificateAuth(callback, options = {}) {
         try {
             const result = callback(cert, req);
             if (isThenable(result)) {
-                Promise.resolve(result).then(doneAuthorizing).catch((err) => {
+                Promise.resolve(result).then(doneAuthorizing).catch((rejection) => {
+                    const err = normalizeCallbackError(rejection);
                     safeCallHook(onRejected, cert, req, err.message || 'callback_threw');
                     if (err.status === undefined) {
                         err.status = 401;
@@ -142,7 +156,8 @@ function clientCertificateAuth(callback, options = {}) {
             } else {
                 doneAuthorizing(result);
             }
-        } catch (err) {
+        } catch (thrown) {
+            const err = normalizeCallbackError(thrown);
             safeCallHook(onRejected, cert, req, err.message || 'callback_threw');
             if (err.status === undefined) {
                 err.status = 401;

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -21,6 +21,19 @@ function isThenable(value) {
 }
 
 /**
+ * Wrap primitive values thrown or rejected by the validation callback in an
+ * Error so `.message` and `.status` access is safe; objects pass through.
+ * @param {unknown} err
+ * @returns {any}
+ */
+function normalizeCallbackError(err) {
+  if (err !== null && (typeof err === 'object' || typeof err === 'function')) {
+    return err;
+  }
+  return new Error(err === null || err === undefined ? '' : String(err));
+}
+
+/**
  * @typedef {import('http').IncomingMessage & { secure?: boolean; socket: import('tls').TLSSocket & { authorized?: boolean; authorizationError?: string }; clientCertificate?: import('tls').PeerCertificate }} ClientCertRequest
  * @typedef {import('http').ServerResponse & { redirect: (statusOrUrl: number | string, url?: string) => void }} ClientCertResponse
  * @typedef {(req: ClientCertRequest, res: ClientCertResponse, next: (err?: Error) => void) => void} Middleware
@@ -191,7 +204,8 @@ export default function clientCertificateAuth(callback, options = {}) {
     try {
       const callbackResult = callback(cert, req);
       if (isThenable(callbackResult)) {
-        Promise.resolve(callbackResult).then(doneAuthorizing).catch((err) => {
+        Promise.resolve(callbackResult).then(doneAuthorizing).catch((rejection) => {
+          const err = normalizeCallbackError(rejection);
           safeCallHook(onRejected, cert, req, err.message || 'callback_threw');
           if (err.status === undefined) {
             err.status = 401;
@@ -201,7 +215,8 @@ export default function clientCertificateAuth(callback, options = {}) {
       } else {
         doneAuthorizing(callbackResult);
       }
-    } catch (err) {
+    } catch (thrown) {
+      const err = normalizeCallbackError(thrown);
       safeCallHook(onRejected, cert, req, err.message || 'callback_threw');
       if (err.status === undefined) {
         err.status = 401;

--- a/test/test-unit-clientCertificateAuth.cjs
+++ b/test/test-unit-clientCertificateAuth.cjs
@@ -174,6 +174,48 @@ describe('clientCertificateAuth (CommonJS)', () => {
                 });
             });
 
+            it('should wrap a thrown string in a 401 Error', done => {
+                const middleware = clientCertificateAuth(() => {
+                    throw 'cert revoked';
+                });
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.message, 'cert revoked');
+                    assert.equal(err.status, 401);
+                    done();
+                });
+            });
+
+            it('should wrap a thrown null in a 401 Error', done => {
+                const middleware = clientCertificateAuth(() => {
+                    throw null;
+                });
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.status, 401);
+                    done();
+                });
+            });
+
+            it('should wrap a string async rejection in a 401 Error', done => {
+                const middleware = clientCertificateAuth(() => Promise.reject('cert revoked'));
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.message, 'cert revoked');
+                    assert.equal(err.status, 401);
+                    done();
+                });
+            });
+
+            it('should wrap a null async rejection in a 401 Error', done => {
+                const middleware = clientCertificateAuth(() => Promise.reject(null));
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.status, 401);
+                    done();
+                });
+            });
+
             it('should set status = 401 on thrown sync errors', done => {
                 const middleware = clientCertificateAuth(() => {
                     throw new Error('Certificate revoked');
@@ -499,6 +541,40 @@ describe('clientCertificateAuth (CommonJS)', () => {
                     setImmediate(() => {
                         assert.ok(hookArgs, 'onRejected should have been called');
                         assert.equal(hookArgs.reason, 'callback_threw');
+                        done();
+                    });
+                });
+            });
+
+            it('should use fallback reason when callback throws null', done => {
+                let hookArgs = null;
+                const middleware = clientCertificateAuth(() => {
+                    throw null;
+                }, {
+                    onRejected: (cert, req, reason) => { hookArgs = { cert, req, reason }; }
+                });
+
+                middleware(mockGoodReq, mockRes, () => {
+                    setImmediate(() => {
+                        assert.ok(hookArgs, 'onRejected should have been called');
+                        assert.equal(hookArgs.reason, 'callback_threw');
+                        done();
+                    });
+                });
+            });
+
+            it('should pass a thrown string to onRejected as the reason', done => {
+                let hookArgs = null;
+                const middleware = clientCertificateAuth(() => {
+                    throw 'cert revoked';
+                }, {
+                    onRejected: (cert, req, reason) => { hookArgs = { cert, req, reason }; }
+                });
+
+                middleware(mockGoodReq, mockRes, () => {
+                    setImmediate(() => {
+                        assert.ok(hookArgs, 'onRejected should have been called');
+                        assert.equal(hookArgs.reason, 'cert revoked');
                         done();
                     });
                 });

--- a/test/test-unit-clientCertificateAuth.js
+++ b/test/test-unit-clientCertificateAuth.js
@@ -184,6 +184,48 @@ describe('clientCertificateAuth', () => {
         });
       });
 
+      it('should wrap a thrown string in a 401 Error', done => {
+        const middleware = clientCertificateAuth(() => {
+          throw 'cert revoked';
+        });
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.message, 'cert revoked');
+          assert.equal(err.status, 401);
+          done();
+        });
+      });
+
+      it('should wrap a thrown null in a 401 Error', done => {
+        const middleware = clientCertificateAuth(() => {
+          throw null;
+        });
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.status, 401);
+          done();
+        });
+      });
+
+      it('should wrap a string async rejection in a 401 Error', done => {
+        const middleware = clientCertificateAuth(() => Promise.reject('cert revoked'));
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.message, 'cert revoked');
+          assert.equal(err.status, 401);
+          done();
+        });
+      });
+
+      it('should wrap a null async rejection in a 401 Error', done => {
+        const middleware = clientCertificateAuth(() => Promise.reject(null));
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.status, 401);
+          done();
+        });
+      });
+
       it('should set status = 401 on thrown sync errors', done => {
         const middleware = clientCertificateAuth(() => {
           throw new Error('Certificate revoked');
@@ -950,6 +992,40 @@ describe('clientCertificateAuth', () => {
           setImmediate(() => {
             assert.ok(hookArgs, 'onRejected should have been called');
             assert.equal(hookArgs.reason, 'callback_threw');
+            done();
+          });
+        });
+      });
+
+      it('should use fallback reason when callback throws null', done => {
+        let hookArgs = null;
+        const middleware = clientCertificateAuth(() => {
+          throw null;
+        }, {
+          onRejected: (cert, req, reason) => { hookArgs = { cert, req, reason }; }
+        });
+
+        middleware(mockGoodReq, mockRes, () => {
+          setImmediate(() => {
+            assert.ok(hookArgs, 'onRejected should have been called');
+            assert.equal(hookArgs.reason, 'callback_threw');
+            done();
+          });
+        });
+      });
+
+      it('should pass a thrown string to onRejected as the reason', done => {
+        let hookArgs = null;
+        const middleware = clientCertificateAuth(() => {
+          throw 'cert revoked';
+        }, {
+          onRejected: (cert, req, reason) => { hookArgs = { cert, req, reason }; }
+        });
+
+        middleware(mockGoodReq, mockRes, () => {
+          setImmediate(() => {
+            assert.ok(hookArgs, 'onRejected should have been called');
+            assert.equal(hookArgs.reason, 'cert revoked');
             done();
           });
         });


### PR DESCRIPTION
Backport to 1.x: a validation callback that threw or rejected with a primitive (a string, null) crashed the middleware's error path with a TypeError instead of producing a 401, and async rejections then escaped as unhandled rejections. Primitives are now wrapped in an Error before hook dispatch and next().