### PR TITLE
Fix prototype pollution vulnerability in the fetch/Request adapter

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -48,7 +48,7 @@ import { extractClientCertificate } from './extractor.js';
 export function extractClientCertificateFromRequest(request, options = {}) {
   // Web Headers normalizes to lowercase, but Map and other iterables
   // preserve casing. Normalize here for the core extractor's lowercase lookup.
-  const headers = {};
+  const headers = Object.create(null);
   for (const [name, value] of request.headers) {
     headers[name.toLowerCase()] = value;
   }

--- a/test/test-unit-fetch.js
+++ b/test/test-unit-fetch.js
@@ -228,6 +228,45 @@ describe('extractClientCertificateFromRequest', () => {
     });
   });
 
+  describe('prototype pollution resistance', () => {
+    it('should not mutate Object.prototype when iterating __proto__ header', () => {
+      // __proto__ as a header name must be treated as a regular header, not
+      // allowed to mutate the prototype of the internal headers object.
+      const headers = new Map([
+        ['x-custom', 'value1'],
+        ['__proto__', 'malicious'],
+        ['client-cert', encodeAsRfc9440(testDer)],
+      ]);
+
+      const result = extractClientCertificateFromRequest({ headers }, {
+        certificateSource: 'cloudflare-rfc9440',
+      });
+
+      // Certificate should still be extracted successfully
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
+
+      // Object.prototype must not be polluted
+      assert.strictEqual(Object.prototype.__proto__, null);
+    });
+
+    it('should not throw when headers iterable yields __proto__', () => {
+      // Even with a non-Map iterable that yields __proto__, the adapter
+      // must not throw or corrupt the headers collection.
+      const headers = new Map([
+        ['__proto__', 'malicious'],
+        ['client-cert', encodeAsRfc9440(testDer)],
+      ]);
+
+      assert.doesNotThrow(() => {
+        const result = extractClientCertificateFromRequest({ headers }, {
+          certificateSource: 'cloudflare-rfc9440',
+        });
+        assert.strictEqual(result.success, true);
+      });
+    });
+  });
+
   describe('header-only behavior', () => {
     it('should never access a socket field even if one is present on the request', () => {
       const headers = new Headers();


### PR DESCRIPTION
*ed. note to future readers: the impact of the problem is significantly overstated here; see the rest of the thread - @tgies*

The problem is that the code builds a headers dictionary using a plain JavaScript object {}. In JavaScript, assigning to headers['__proto__'] doesn't create a regular key-value pair — it triggers the special __proto__ accessor, which changes the object's prototype. This means:

The __proto__ header value gets lost — you can't read it back by key lookup
The object's prototype chain gets mutated, which can cause unexpected behavior for any code that interacts with that headers object
