### PR TITLE
fix(fetch): fix `headers` prototype chain

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -48,7 +48,7 @@ import { extractClientCertificate } from './extractor.js';
 export function extractClientCertificateFromRequest(request, options = {}) {
   // Web Headers normalizes to lowercase, but Map and other iterables
   // preserve casing. Normalize here for the core extractor's lowercase lookup.
-  const headers = {};
+  const headers = Object.create(null);
   for (const [name, value] of request.headers) {
     headers[name.toLowerCase()] = value;
   }

--- a/test/test-unit-fetch.js
+++ b/test/test-unit-fetch.js
@@ -213,6 +213,24 @@ describe('extractClientCertificateFromRequest', () => {
       assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
     });
 
+    it('should not be affected by Object.prototype properties when a header name collides', () => {
+      // `__proto__` will exist as a magic setter if the headers object isn't
+      // defined as a bare dictionary (i.e. via `Object.create(null)`), causing
+      // this to fail. The asserted behavior is that setting a property called
+      // `__proto__` just creates a string-valued property called `__proto__`.
+      const headers = new Map([
+        ['__proto__', encodeAsRfc9440(testDer)],
+      ]);
+
+      const result = extractClientCertificateFromRequest({ headers }, {
+        certificateHeader: '__proto__',
+        headerEncoding: 'rfc9440',
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
+    });
+
     it('should normalize header names to lowercase for the RequestLike Map path', () => {
       // Map preserves casing; mixed-case keys need lowercasing.
       const headers = new Map([


### PR DESCRIPTION
`headers = {}` creates an object that has properties like `__proto__` and friends. If (for some reason) a header has a name collision with one of these, unexpected behavior occurs (i.e. in the `__proto__` case the header is lost because `__proto__` is a special setter that silently discards anything that isn't an Object or null).

Changes `headers` to a bare dict (`Object.create(null)`). Adds a test to assert no name collision on `__proto__`.

Supplants #150, which identified the bug correctly, but overstated the impact in the commit message and added incorrect tests.

Credit to @Mayne-X for the bug report.