### PR TITLE
fix(extractor): fail closed on non-string certificate header values

### DIFF
--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -163,7 +163,8 @@ export function extractClientCertificate(req, options = {}) {
       const chainEncoding = headerEncoding ?? preset?.encoding;
       if (chainHeaderName && chainEncoding) {
         const chainHeaderValue = req.headers[chainHeaderName];
-        if (chainHeaderValue && !Array.isArray(chainHeaderValue)) {
+        // Only a non-empty string is parseable; anything else leaves the leaf unchained.
+        if (typeof chainHeaderValue === 'string' && chainHeaderValue) {
           const chainCerts = chainHeaderValue
             .split(',')
             .map(item => item.trim())

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -403,6 +403,11 @@ export function derToCertificate(der) {
  * @returns {PeerCertificate | null} Parsed certificate or null on failure
  */
 export function parseHeaderValue(headerValue, encoding) {
+    // Only strings are parseable; a header name like 'constructor' resolves
+    // to a function on plain-object header maps.
+    if (typeof headerValue !== 'string') {
+        return null;
+    }
     switch (encoding) {
         // Stryker disable next-line ConditionalExpression: parseUrlPem/parseUrlPemAws are equivalent for inputs without + chars
         case 'url-pem':

--- a/test/test-unit-clientCertificateAuth.js
+++ b/test/test-unit-clientCertificateAuth.js
@@ -564,6 +564,50 @@ describe('clientCertificateAuth', () => {
         });
       });
 
+      it('should return 401 when certificateHeader collides with an Object.prototype member', done => {
+        // 'constructor' resolves to a function through the prototype chain
+        // of the plain headers object; Node's req.headers is not null-prototype.
+        const req = {
+          secure: false,
+          socket: { authorized: false },
+          headers: {}
+        };
+
+        const middleware = clientCertificateAuth(() => true, {
+          certificateHeader: 'constructor',
+          headerEncoding: 'base64-der'
+        });
+
+        middleware(req, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.status, 401);
+          assert.ok(err.message.includes('header missing or malformed'));
+          done();
+        });
+      });
+
+      it('should return 401 when certificate header value is not a string', done => {
+        const req = {
+          secure: false,
+          socket: { authorized: false },
+          headers: {
+            'x-custom-cert': 123
+          }
+        };
+
+        const middleware = clientCertificateAuth(() => true, {
+          certificateHeader: 'X-Custom-Cert',
+          headerEncoding: 'url-pem'
+        });
+
+        middleware(req, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.status, 401);
+          assert.ok(err.message.includes('header missing or malformed'));
+          done();
+        });
+      });
+
       describe('verifyHeader/verifyValue options', () => {
         it('should reject if verifyHeader is set but header is missing', done => {
           const encodedCert = encodeURIComponent(testPem);

--- a/test/test-unit-extractor.js
+++ b/test/test-unit-extractor.js
@@ -737,6 +737,71 @@ describe('extractClientCertificate', () => {
         assert.ok(result.certificate);
         assert.strictEqual(result.certificate.issuerCertificate, undefined);
       });
+
+      it('should ignore chain header when its name collides with an Object.prototype member', () => {
+        const leafDer = pemToDer(testPem);
+
+        const req = {
+          headers: {
+            'client-cert': encodeAsRfc9440(leafDer),
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'cloudflare-rfc9440',
+          chainHeader: 'constructor',
+          includeChain: true,
+        });
+
+        // 'constructor' resolves to a function through the prototype chain
+        // of the plain headers object.
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.strictEqual(result.certificate.issuerCertificate, undefined);
+      });
+
+      it('should ignore chain header when its value is not a string', () => {
+        const leafDer = pemToDer(testPem);
+
+        const req = {
+          headers: {
+            'client-cert': encodeAsRfc9440(leafDer),
+            'client-cert-chain': 42,
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'cloudflare-rfc9440',
+          includeChain: true,
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.strictEqual(result.certificate.issuerCertificate, undefined);
+      });
+
+      it('should ignore chain header when its value is an empty string', () => {
+        const leafDer = pemToDer(testPem);
+
+        const req = {
+          headers: {
+            'client-cert': encodeAsRfc9440(leafDer),
+            'client-cert-chain': '',
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateSource: 'cloudflare-rfc9440',
+          includeChain: true,
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.ok(result.certificate);
+        assert.strictEqual(result.certificate.issuerCertificate, undefined);
+      });
     });
 
     describe('custom header', () => {

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -636,6 +636,14 @@ describe('parsers module', () => {
             assert.equal(parseHeaderValue('test', 'unknown-encoding'), null);
         });
 
+        it('should return null for non-string input', () => {
+            // A header name like 'constructor' resolves to a function on
+            // plain-object header maps.
+            assert.equal(parseHeaderValue(Object, 'base64-der'), null);
+            assert.equal(parseHeaderValue(42, 'url-pem'), null);
+            assert.equal(parseHeaderValue(null, 'xfcc'), null);
+        });
+
         it('should return null for url-pem with empty input', () => {
             // Explicitly tests url-pem case in switch (kills switch body mutation)
             assert.equal(parseHeaderValue('', 'url-pem'), null);


### PR DESCRIPTION
## Problem

A `certificateHeader` or `chainHeader` configured with a name that collides with an `Object.prototype` member (`constructor`, `toString`, ...) crashes the middleware instead of failing closed. Node's `req.headers` is a plain object (not null-prototype), so `headers['constructor']` resolves to a function even when no such header was sent. `parseBase64Der` then calls `.split()` on that function outside any try/catch:

```
TypeError: headerValue.split is not a function
```

Thrown synchronously out of the middleware on every request — a 500 in Express, an uncaught exception (process crash) in a bare `http` server. No spoofed header required; the configured header just has to be absent.

## Fix

- `parseHeaderValue()` rejects non-string input before dispatching to the per-encoding parsers (covers the leaf header and direct `/parsers` consumers).
- The chain-header block in the extractor only splits values that are actually strings; the leaf cert still stands on its own.

## Tests

- Middleware: `certificateHeader: 'constructor'` now yields a 401, not a `TypeError`; non-string header values fail closed the same way.
- Extractor: a chain header named `constructor`, or holding a non-string/empty value, is ignored while the leaf parses.
- `parseHeaderValue` rejects functions/numbers/null directly.

Coverage stays at 100% on all four metrics.