### PR TITLE
docs(helpers): correct SHA256 fingerprint prefix comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,8 +669,8 @@ app.use(clientCertificateAuth(allowCN(['service-a', 'service-b'])));
 
 // Allowlist by fingerprint
 app.use(clientCertificateAuth(allowFingerprints([
-  'SHA256:AB:CD:EF:...',
-  'AB:CD:EF:...'  // SHA256: prefix optional
+  'SHA256:AB:CD:EF:...',  // matched against cert.fingerprint256
+  'AB:CD:EF:...'          // SHA-1, matched against cert.fingerprint
 ])));
 
 // Allowlist by Organization

--- a/docs/guide/helpers.md
+++ b/docs/guide/helpers.md
@@ -21,8 +21,8 @@ app.use(clientCertificateAuth(allowCN(['service-a', 'service-b'])));
 
 // Allowlist by fingerprint
 app.use(clientCertificateAuth(allowFingerprints([
-  'SHA256:AB:CD:EF:...',
-  'AB:CD:EF:...'  // SHA256: prefix optional
+  'SHA256:AB:CD:EF:...',  // matched against cert.fingerprint256
+  'AB:CD:EF:...'          // SHA-1, matched against cert.fingerprint
 ])));
 
 // Allowlist by Organization


### PR DESCRIPTION
The example comment in the README and helpers guide claimed the `SHA256:` prefix was optional:

```js
app.use(clientCertificateAuth(allowFingerprints([
  'SHA256:AB:CD:EF:...',
  'AB:CD:EF:...'  // SHA256: prefix optional
])));
```

It isn't. `allowFingerprints` routes unprefixed values to the SHA-1 set and only compares them against `cert.fingerprint`; `cert.fingerprint256` is consulted solely for `SHA256:`-prefixed entries. Anyone following the comment with an unprefixed SHA-256 fingerprint gets an allowlist that never matches (fails closed, but broken). The comment also contradicted the JSDoc and generated API reference, which describe the routing correctly.

Updated both spots to spell out which field each form matches.