### PR TITLE
test(stryker): annotate equivalent mutants on the array header guard

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -473,6 +473,7 @@ export function getCertificateFromHeaders(headers, config) {
 
     // Node.js HTTP consolidates duplicate headers into string[].
     // Parsers expect a single string; reject arrays to fail safely.
+    // Stryker disable next-line ConditionalExpression,BlockStatement: →false/{} equivalent (parseHeaderValue rejects non-strings); →true killed by valid header extraction tests
     if (Array.isArray(headerValue)) {
         return null;
     }


### PR DESCRIPTION
The two survivors at `parsers.js:476` are equivalent now that `parseHeaderValue` rejects non-strings; the guard itself stays.