### PR TITLE
fix(parsers): reject multi-block headers whose leaf fails to parse

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -138,8 +138,9 @@ function splitPemBlocks(pem) {
 
 /**
  * Parse a multi-block PEM blob into a chained PeerCertificate. Splits the
- * input into individual blocks, parses each, drops blocks that fail to
- * parse, and links the remainder via issuerCertificate.
+ * input into individual blocks and links them via issuerCertificate. The
+ * first block is the leaf and must parse; later blocks that fail to parse
+ * are dropped and the chain links past them.
  *
  * Used by parsers whose proxies forward the full chain in a single field
  * (parseUrlPemAws, parseXfcc Chain). Without explicit chain linking, calling
@@ -152,22 +153,27 @@ function splitPemBlocks(pem) {
  */
 function chainFromMultiBlockPem(pem) {
     const pemBlocks = splitPemBlocks(pem);
-    // Stryker disable next-line BlockStatement,ConditionalExpression: short-circuit; falling through hits the next certs.length===0 check with the same null result
+    // Stryker disable next-line BlockStatement,ConditionalExpression: short-circuit; falling through hands undefined to pemToCertificate, which throws for the same null result
     if (pemBlocks.length === 0) {
         return null;
     }
 
-    const certs = pemBlocks.map(block => {
-        try {
-            return pemToCertificate(block);
-        } catch {
-            // Equivalent mutant (undefined also filtered by .filter(Boolean)) — catch-body BlockStatement unsuppressible via Stryker comments
-            return null;
-        }
-    }).filter(Boolean);
-
-    if (certs.length === 0) {
+    // An unparseable leaf rejects the whole blob. Promoting the next block
+    // would authenticate the request as whichever certificate parsed first.
+    let leaf;
+    try {
+        leaf = pemToCertificate(pemBlocks[0]);
+    } catch {
         return null;
+    }
+
+    const certs = [leaf];
+    for (const block of pemBlocks.slice(1)) {
+        try {
+            certs.push(pemToCertificate(block));
+        } catch {
+            // Dropped; the chain links past it.
+        }
     }
 
     // Stryker disable next-line EqualityOperator: setting issuerCertificate = undefined on last cert is same as not setting it
@@ -309,24 +315,27 @@ export function parseBase64Der(headerValue) {
     // Stryker disable next-line MethodExpression: .trim() no-op (base64 ignores whitespace); .filter(Boolean) redundant (empty strings throw in X509Certificate, caught below)
     const certParts = headerValue.split(',').map(s => s.trim()).filter(Boolean);
 
-    // Stryker disable next-line BlockStatement,ConditionalExpression: →false equivalent (empty array → zero certs → certs.length===0 catches it); →true killed by valid base64-der tests
+    // Stryker disable next-line BlockStatement,ConditionalExpression: →false equivalent (empty array → undefined leaf → derToCertificate throws for the same null); →true killed by valid base64-der tests
     if (certParts.length === 0) {
         return null;
     }
 
-    // Parse all certs in the chain
-    const certs = certParts.map(base64 => {
-        try {
-            const derBuffer = Buffer.from(base64, 'base64');
-            return derToCertificate(derBuffer);
-        } catch {
-            // Equivalent mutant (undefined also filtered by .filter(Boolean)) — catch-body BlockStatement unsuppressible via Stryker comments
-            return null;
-        }
-    }).filter(Boolean);
-
-    if (certs.length === 0) {
+    // An unparseable leaf rejects the whole header. Promoting the next entry
+    // would authenticate the request as whichever certificate parsed first.
+    let leaf;
+    try {
+        leaf = derToCertificate(Buffer.from(certParts[0], 'base64'));
+    } catch {
         return null;
+    }
+
+    const certs = [leaf];
+    for (const base64 of certParts.slice(1)) {
+        try {
+            certs.push(derToCertificate(Buffer.from(base64, 'base64')));
+        } catch {
+            // Dropped; the chain links past it.
+        }
     }
 
     // Link the cert chain via issuerCertificate

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -192,6 +192,15 @@ describe('parsers module', () => {
             assert.equal(cert.subject.CN, 'Test Parser Client');
         });
 
+        it('should return null when the leading PEM block is malformed', () => {
+            // The leaf must parse on its own; the valid block behind it is not
+            // promoted into the leaf position.
+            const invalidBlock = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64\n-----END CERTIFICATE-----\n';
+            const encoded = encodeAsAwsAlb(invalidBlock + testPem);
+
+            assert.equal(parseUrlPemAws(encoded), null);
+        });
+
         it('should return null when every PEM block in a chain is malformed', () => {
             const invalidBlock1 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_1\n-----END CERTIFICATE-----\n';
             const invalidBlock2 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_2\n-----END CERTIFICATE-----\n';
@@ -451,6 +460,13 @@ describe('parsers module', () => {
             assert.equal(cert.issuerCertificate.subject.CN, 'Test Intermediate');
         });
 
+        it('should return null when the leading block in multi-block Chain is malformed', () => {
+            const invalidBlock = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64\n-----END CERTIFICATE-----\n';
+            const xfcc = `Hash=abc;Chain="${encodeURIComponent(invalidBlock + testPem)}"`;
+
+            assert.equal(parseXfcc(xfcc), null);
+        });
+
         it('should return null when every block in multi-block Chain is invalid', () => {
             const invalidBlock1 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_1\n-----END CERTIFICATE-----\n';
             const invalidBlock2 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_2\n-----END CERTIFICATE-----\n';
@@ -543,15 +559,20 @@ describe('parsers module', () => {
                 'only two valid certs in chain, not three');
         });
 
-        it('should return single valid cert when others in chain are invalid', () => {
+        it('should return null when the leading cert in a chain is invalid', () => {
             const validBase64 = encodeAsCloudflare(testDer);
             const invalidBase64 = Buffer.from('invalid-cert-data').toString('base64');
 
-            const result = parseBase64Der(`${invalidBase64},${validBase64},${invalidBase64}`);
-            assert.ok(result);
-            assert.equal(result.subject.CN, 'Test Parser Client');
-            assert.equal(result.issuerCertificate, undefined,
-                'single surviving cert should not have issuerCertificate');
+            // The leaf is the identity the request authenticates as, so a
+            // later entry must never be promoted into its place.
+            assert.equal(parseBase64Der(`${invalidBase64},${validBase64},${invalidBase64}`), null);
+        });
+
+        it('should return null when only trailing certs in a chain are valid', () => {
+            const validBase64 = encodeAsCloudflare(testDer);
+            const invalidBase64 = Buffer.from('invalid-cert-data').toString('base64');
+
+            assert.equal(parseBase64Der(`${invalidBase64},${validBase64}`), null);
         });
     });
 


### PR DESCRIPTION
- A corrupted leading certificate used to promote the next entry into the leaf position, so the request authenticated as that certificate. `chainFromMultiBlockPem` and `parseBase64Der` now require the first block to parse.
- Later blocks that fail to parse are still dropped and the chain links past them.
- Affects `url-pem-aws` (aws-alb), `xfcc` (envoy), and `base64-der` (traefik, azure-app-service, cloudflare). Rewrites the base64-der test that pinned the old tolerance.