### PR TITLE
fix(parsers): link certificate chains carried in url-pem headers

### DIFF
--- a/lib/extractor.d.ts
+++ b/lib/extractor.d.ts
@@ -1,7 +1,7 @@
 /**
  * @typedef {Object} ExtractionResult
  * @property {boolean} success - Whether extraction succeeded
- * @property {import('tls').PeerCertificate | null} certificate - Extracted certificate (null on failure)
+ * @property {import('./parsers.js').ChainedPeerCertificate | null} certificate - Extracted certificate (null on failure)
  * @property {string | null} reason - Rejection reason code (null on success)
  *
  * Rejection reasons:
@@ -74,7 +74,7 @@ export type ExtractionResult = {
     /**
      * - Extracted certificate (null on failure)
      */
-    certificate: import("tls").PeerCertificate | null;
+    certificate: import("./parsers.js").ChainedPeerCertificate | null;
     /**
      * - Rejection reason code (null on success)
      *

--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -56,7 +56,7 @@ export function validateExtractorOptions(options = {}) {
 /**
  * @typedef {Object} ExtractionResult
  * @property {boolean} success - Whether extraction succeeded
- * @property {import('tls').PeerCertificate | null} certificate - Extracted certificate (null on failure)
+ * @property {import('./parsers.js').ChainedPeerCertificate | null} certificate - Extracted certificate (null on failure)
  * @property {string | null} reason - Rejection reason code (null on success)
  *
  * Rejection reasons:

--- a/lib/parsers.d.ts
+++ b/lib/parsers.d.ts
@@ -7,6 +7,14 @@
 import type { PeerCertificate } from 'tls';
 
 /**
+ * A certificate with an optional issuer chain. Header-extracted chains end at
+ * the topmost certificate, while Node's socket chains self-reference at the root.
+ */
+export type ChainedPeerCertificate = PeerCertificate & {
+    issuerCertificate?: ChainedPeerCertificate;
+};
+
+/**
  * Supported header encoding formats.
  */
 export type HeaderEncoding = 'url-pem' | 'url-pem-aws' | 'xfcc' | 'base64-der' | 'rfc9440';
@@ -60,26 +68,26 @@ export interface CertificateHeaderConfig {
  * Parse URL-encoded PEM certificate (nginx, HAProxy format).
  * @see https://nginx.org/en/docs/http/ngx_http_ssl_module.html#var_ssl_client_escaped_cert
  */
-export declare function parseUrlPem(headerValue: string): PeerCertificate | null;
+export declare function parseUrlPem(headerValue: string): ChainedPeerCertificate | null;
 
 /**
  * Parse URL-encoded PEM certificate with AWS ALB safe character handling.
  * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/mutual-authentication.html
  */
-export declare function parseUrlPemAws(headerValue: string): PeerCertificate | null;
+export declare function parseUrlPemAws(headerValue: string): ChainedPeerCertificate | null;
 
 /**
  * Parse Envoy XFCC (X-Forwarded-Client-Cert) structured header format.
  * @see https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert
  */
-export declare function parseXfcc(headerValue: string): PeerCertificate | null;
+export declare function parseXfcc(headerValue: string): ChainedPeerCertificate | null;
 
 /**
  * Parse base64-encoded DER certificate (Cloudflare, Traefik format).
  * Also handles Traefik's comma-separated cert chains.
  * @see https://developers.cloudflare.com/api-shield/security/mtls/configure/
  */
-export declare function parseBase64Der(headerValue: string): PeerCertificate | null;
+export declare function parseBase64Der(headerValue: string): ChainedPeerCertificate | null;
 
 /**
  * Parse RFC 9440 format certificate (used by Google Cloud Load Balancer).
@@ -103,7 +111,7 @@ export declare function derToCertificate(der: Buffer): PeerCertificate;
 export declare function parseHeaderValue(
     headerValue: string,
     encoding: HeaderEncoding
-): PeerCertificate | null;
+): ChainedPeerCertificate | null;
 
 /**
  * Get certificate from request headers using configuration.
@@ -111,4 +119,4 @@ export declare function parseHeaderValue(
 export declare function getCertificateFromHeaders(
     headers: Record<string, string | string[] | undefined>,
     config: CertificateHeaderConfig
-): PeerCertificate | null;
+): ChainedPeerCertificate | null;

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -12,6 +12,12 @@ import { X509Certificate } from 'node:crypto';
  */
 
 /**
+ * A certificate with an optional issuer chain. Header-extracted chains end at
+ * the topmost certificate, while Node's socket chains self-reference at the root.
+ * @typedef {PeerCertificate & { issuerCertificate?: ChainedPeerCertificate }} ChainedPeerCertificate
+ */
+
+/**
  * Preset configurations for common reverse proxies.
  * Maps preset name to { header, encoding } configuration, with optional
  * `chainHeader` for two-header schemes (RFC 9440).
@@ -89,10 +95,11 @@ export const PRESETS = {
 /**
  * Parse URL-encoded PEM certificate (nginx, HAProxy format).
  * Uses standard URL encoding via $ssl_client_escaped_cert or similar.
+ * Concatenated PEM blocks are split and linked via issuerCertificate.
  * 
  * @see https://nginx.org/en/docs/http/ngx_http_ssl_module.html#var_ssl_client_escaped_cert
  * @param {string} headerValue - URL-encoded PEM certificate
- * @returns {PeerCertificate | null} Parsed certificate or null on failure
+ * @returns {ChainedPeerCertificate | null} Parsed certificate or null on failure
  */
 export function parseUrlPem(headerValue) {
     // Stryker disable next-line BlockStatement,ConditionalExpression: falsy input falls through to try-catch → same null return
@@ -102,7 +109,7 @@ export function parseUrlPem(headerValue) {
 
     try {
         const pem = decodeURIComponent(headerValue);
-        return pemToCertificate(pem);
+        return chainFromMultiBlockPem(pem);
     } catch {
         return null;
     }
@@ -143,13 +150,13 @@ function splitPemBlocks(pem) {
  * are dropped and the chain links past them.
  *
  * Used by parsers whose proxies forward the full chain in a single field
- * (parseUrlPemAws, parseXfcc Chain). Without explicit chain linking, calling
- * X509Certificate() on a multi-block PEM returns just the leaf with no
+ * (parseUrlPem, parseUrlPemAws, parseXfcc Chain). Without explicit chain
+ * linking, calling X509Certificate() on a multi-block PEM returns just the leaf with no
  * issuerCertificate (toLegacyObject drops the property), silently losing
  * chain information for `includeChain: true` consumers.
  *
  * @param {string} pem - Concatenated PEM blocks
- * @returns {PeerCertificate | null} Leaf cert with chain via issuerCertificate, or null if no blocks parse
+ * @returns {ChainedPeerCertificate | null} Leaf cert with chain via issuerCertificate, or null if the leaf does not parse
  */
 function chainFromMultiBlockPem(pem) {
     const pemBlocks = splitPemBlocks(pem);
@@ -192,7 +199,7 @@ function chainFromMultiBlockPem(pem) {
  *
  * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/mutual-authentication.html
  * @param {string} headerValue - AWS ALB URL-encoded PEM certificate
- * @returns {PeerCertificate | null} Parsed certificate or null on failure
+ * @returns {ChainedPeerCertificate | null} Parsed certificate or null on failure
  */
 export function parseUrlPemAws(headerValue) {
     // Stryker disable next-line BlockStatement,ConditionalExpression: falsy input falls through to try-catch → same null return
@@ -220,7 +227,7 @@ export function parseUrlPemAws(headerValue) {
  *
  * @see https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert
  * @param {string} headerValue - XFCC formatted header value
- * @returns {PeerCertificate | null} Parsed certificate or null on failure
+ * @returns {ChainedPeerCertificate | null} Parsed certificate or null on failure
  */
 export function parseXfcc(headerValue) {
     // Stryker disable next-line BlockStatement,ConditionalExpression: falsy input falls through to try-catch → same null return
@@ -303,7 +310,7 @@ export function parseXfcc(headerValue) {
  * 
  * @see https://developers.cloudflare.com/api-shield/security/mtls/configure/
  * @param {string} headerValue - Base64-encoded DER certificate(s)
- * @returns {PeerCertificate | null} Parsed certificate or null on failure
+ * @returns {ChainedPeerCertificate | null} Parsed certificate or null on failure
  */
 export function parseBase64Der(headerValue) {
     // Stryker disable next-line BlockStatement,ConditionalExpression: falsy input falls through to try-catch → same null return
@@ -409,7 +416,7 @@ export function derToCertificate(der) {
  * 
  * @param {string} headerValue - Raw header value
  * @param {'url-pem' | 'url-pem-aws' | 'xfcc' | 'base64-der' | 'rfc9440'} encoding - Encoding format
- * @returns {PeerCertificate | null} Parsed certificate or null on failure
+ * @returns {ChainedPeerCertificate | null} Parsed certificate or null on failure
  */
 export function parseHeaderValue(headerValue, encoding) {
     // Only strings are parseable; a header name like 'constructor' resolves
@@ -442,7 +449,7 @@ export function parseHeaderValue(headerValue, encoding) {
  * @param {string} [config.certificateSource] - Preset name (aws-alb, envoy, cloudflare, traefik)
  * @param {string} [config.certificateHeader] - Custom header name (overrides preset)
  * @param {string} [config.headerEncoding] - Encoding format (required if certificateHeader is set)
- * @returns {PeerCertificate | null} Parsed certificate or null if not found/invalid
+ * @returns {ChainedPeerCertificate | null} Parsed certificate or null if not found/invalid
  */
 export function getCertificateFromHeaders(headers, config) {
     let headerName;

--- a/test/test-typescript-types.ts
+++ b/test/test-typescript-types.ts
@@ -260,6 +260,21 @@ const _badNewSource = clientCertificateAuth(() => true, {
     certificateSource: 'azure-application-gateway',
 });
 
+// Test 26: chain access on an extraction result needs no narrowing, and the
+// chain terminates rather than recursing forever like DetailedPeerCertificate
+import { extractClientCertificate } from '../lib/extractor.js';
+import type { ChainedPeerCertificate } from '../lib/parsers.js';
+
+function testChainAccess(req: Parameters<typeof extractClientCertificate>[0]): string | string[] | undefined {
+    const result = extractClientCertificate(req, { certificateSource: 'aws-alb', includeChain: true });
+    return result.certificate?.issuerCertificate?.issuerCertificate?.subject?.CN;
+}
+
+const _terminatingChain: ChainedPeerCertificate = {
+    ...({} as ChainedPeerCertificate),
+    issuerCertificate: undefined,
+};
+
 // Suppress unused variable warnings - this file is for type-checking only
 void _statusCode;
 void _syncMiddleware;
@@ -291,3 +306,5 @@ void testFetchExtractorPlainObject;
 void testCjsFetchLoad;
 void _chainHeaderOption;
 void _badNewSource;
+void testChainAccess;
+void _terminatingChain;

--- a/test/test-unit-extractor.js
+++ b/test/test-unit-extractor.js
@@ -361,6 +361,77 @@ describe('extractClientCertificate', () => {
         assert.ok(result.certificate);
         assert.strictEqual(result.certificate.subject.CN, 'client.example.com');
       });
+
+      it('should link a chain carried in a multi-block url-pem header', async () => {
+        const selfsigned = (await import('selfsigned')).default;
+        const intermediate = await selfsigned.generate(
+          [{ name: 'commonName', value: 'Intermediate CA' }],
+          { algorithm: 'sha256', keySize: 2048, days: 1 }
+        );
+
+        const req = {
+          headers: {
+            'x-custom-cert': encodeURIComponent(`${testPem}\n${intermediate.cert}`),
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateHeader: 'X-Custom-Cert',
+          headerEncoding: 'url-pem',
+          includeChain: true,
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.strictEqual(result.certificate.subject.CN, 'client.example.com');
+        assert.ok(result.certificate.issuerCertificate);
+        assert.strictEqual(result.certificate.issuerCertificate.subject.CN, 'Intermediate CA');
+      });
+
+      it('should strip the url-pem chain when includeChain is false', async () => {
+        const selfsigned = (await import('selfsigned')).default;
+        const intermediate = await selfsigned.generate(
+          [{ name: 'commonName', value: 'Intermediate CA' }],
+          { algorithm: 'sha256', keySize: 2048, days: 1 }
+        );
+
+        const req = {
+          headers: {
+            'x-custom-cert': encodeURIComponent(`${testPem}\n${intermediate.cert}`),
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateHeader: 'X-Custom-Cert',
+          headerEncoding: 'url-pem',
+        });
+
+        assert.strictEqual(result.success, true);
+        assert.strictEqual(result.certificate.subject.CN, 'client.example.com');
+        assert.strictEqual(result.certificate.issuerCertificate, undefined);
+      });
+
+      it('should reject a url-pem header whose leading block is malformed', () => {
+        const invalidBlock = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64\n-----END CERTIFICATE-----\n';
+
+        const req = {
+          headers: {
+            'x-custom-cert': encodeURIComponent(`${invalidBlock}${testPem}`),
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, {
+          certificateHeader: 'X-Custom-Cert',
+          headerEncoding: 'url-pem',
+          includeChain: true,
+        });
+
+        assert.strictEqual(result.success, false);
+        assert.strictEqual(result.certificate, null);
+        assert.strictEqual(result.reason, 'header_missing_or_malformed');
+      });
     });
 
     describe('Cloudflare preset', () => {

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -157,6 +157,37 @@ describe('parsers module', () => {
             const encoded = encodeURIComponent('not a certificate');
             assert.equal(parseUrlPem(encoded), null);
         });
+
+        it('should link a multi-block chain via issuerCertificate', async () => {
+            const intermediate = await generateClientCertificate('Test Intermediate');
+            const encoded = encodeAsNginx(`${testPem}\n${intermediate.cert}`);
+
+            const cert = parseUrlPem(encoded);
+
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+            assert.ok(cert.issuerCertificate);
+            assert.equal(cert.issuerCertificate.subject.CN, 'Test Intermediate');
+            assert.equal(cert.issuerCertificate.issuerCertificate, undefined);
+        });
+
+        it('should drop a trailing malformed block and return the leaf', () => {
+            const invalidBlock = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64\n-----END CERTIFICATE-----\n';
+            const encoded = encodeAsNginx(`${testPem}\n${invalidBlock}`);
+
+            const cert = parseUrlPem(encoded);
+
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+            assert.equal(cert.issuerCertificate, undefined);
+        });
+
+        it('should return null when the leading PEM block is malformed', () => {
+            const invalidBlock = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64\n-----END CERTIFICATE-----\n';
+            const encoded = encodeAsNginx(`${invalidBlock}${testPem}`);
+
+            assert.equal(parseUrlPem(encoded), null);
+        });
     });
 
     describe('parseUrlPemAws (AWS ALB format)', () => {


### PR DESCRIPTION
- `parseUrlPem` returned only the leaf, so a multi-block PEM in an nginx-style header lost its chain and `includeChain: true` produced a certificate with no `issuerCertificate`, contradicting README.md:355.
- Routes through `chainFromMultiBlockPem`, so it inherits the leaf-strict policy from #187.
- Adds `ChainedPeerCertificate` (`PeerCertificate` with an optional recursive `issuerCertificate`) for the chain-capable parsers and `ExtractionResult`. `DetailedPeerCertificate` does not fit: it requires `issuerCertificate` at every level, and header chains terminate.