### PR TITLE
fix(parsers): reject headers whose leaf slot is empty or unrecognizable

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -165,6 +165,12 @@ function chainFromMultiBlockPem(pem) {
         return null;
     }
 
+    // Junk ahead of the leaf block means the leaf was damaged past recognition;
+    // the next block must not slide into its place. Leading whitespace is fine.
+    if (pem.slice(0, pem.indexOf(pemBlocks[0])).trim() !== '') {
+        return null;
+    }
+
     // An unparseable leaf rejects the whole blob. Promoting the next block
     // would authenticate the request as whichever certificate parsed first.
     let leaf;
@@ -319,16 +325,11 @@ export function parseBase64Der(headerValue) {
     }
 
     // Handle comma-separated cert chains (Traefik format)
-    // Stryker disable next-line MethodExpression: .trim() no-op (base64 ignores whitespace); .filter(Boolean) redundant (empty strings throw in X509Certificate, caught below)
-    const certParts = headerValue.split(',').map(s => s.trim()).filter(Boolean);
+    // Stryker disable next-line MethodExpression: .trim() no-op (base64 ignores whitespace)
+    const certParts = headerValue.split(',').map(s => s.trim());
 
-    // Stryker disable next-line BlockStatement,ConditionalExpression: →false equivalent (empty array → undefined leaf → derToCertificate throws for the same null); →true killed by valid base64-der tests
-    if (certParts.length === 0) {
-        return null;
-    }
-
-    // An unparseable leaf rejects the whole header. Promoting the next entry
-    // would authenticate the request as whichever certificate parsed first.
+    // An empty or unparseable leaf rejects the whole header. Promoting the next
+    // entry would authenticate the request as whichever certificate parsed first.
     let leaf;
     try {
         leaf = derToCertificate(Buffer.from(certParts[0], 'base64'));

--- a/test/test-unit-extractor.js
+++ b/test/test-unit-extractor.js
@@ -412,6 +412,21 @@ describe('extractClientCertificate', () => {
         assert.strictEqual(result.certificate.issuerCertificate, undefined);
       });
 
+      it('should reject a traefik header whose leading chain entry is empty', () => {
+        const req = {
+          headers: {
+            'x-forwarded-tls-client-cert': `,${pemToDer(testPem).toString('base64')}`,
+          },
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, { certificateSource: 'traefik' });
+
+        assert.strictEqual(result.success, false);
+        assert.strictEqual(result.certificate, null);
+        assert.strictEqual(result.reason, 'header_missing_or_malformed');
+      });
+
       it('should reject a url-pem header whose leading block is malformed', () => {
         const invalidBlock = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64\n-----END CERTIFICATE-----\n';
 

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -188,6 +188,22 @@ describe('parsers module', () => {
 
             assert.equal(parseUrlPem(encoded), null);
         });
+
+        it('should return null when junk precedes the first PEM block', () => {
+            // A leaf mangled past its markers is not a block at all, so the
+            // next certificate would otherwise take the leaf position.
+            const encoded = encodeAsNginx(`----BEGIN CERTIFICATE-----\nQUJD\n-----END CERT-----\n${testPem}`);
+
+            assert.equal(parseUrlPem(encoded), null);
+        });
+
+        it('should tolerate whitespace before the first PEM block', () => {
+            const encoded = encodeAsNginx(`\n  \n${testPem}`);
+            const cert = parseUrlPem(encoded);
+
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+        });
     });
 
     describe('parseUrlPemAws (AWS ALB format)', () => {
@@ -228,6 +244,12 @@ describe('parsers module', () => {
             // promoted into the leaf position.
             const invalidBlock = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64\n-----END CERTIFICATE-----\n';
             const encoded = encodeAsAwsAlb(invalidBlock + testPem);
+
+            assert.equal(parseUrlPemAws(encoded), null);
+        });
+
+        it('should return null when junk precedes the first PEM block', () => {
+            const encoded = encodeAsAwsAlb(`GARBAGE TEXT\n${testPem}`);
 
             assert.equal(parseUrlPemAws(encoded), null);
         });
@@ -498,6 +520,12 @@ describe('parsers module', () => {
             assert.equal(parseXfcc(xfcc), null);
         });
 
+        it('should return null when junk precedes the first block in Chain', () => {
+            const xfcc = `Hash=abc;Chain="${encodeURIComponent(`GARBAGE TEXT\n${testPem}`)}"`;
+
+            assert.equal(parseXfcc(xfcc), null);
+        });
+
         it('should return null when every block in multi-block Chain is invalid', () => {
             const invalidBlock1 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_1\n-----END CERTIFICATE-----\n';
             const invalidBlock2 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_2\n-----END CERTIFICATE-----\n';
@@ -597,6 +625,22 @@ describe('parsers module', () => {
             // The leaf is the identity the request authenticates as, so a
             // later entry must never be promoted into its place.
             assert.equal(parseBase64Der(`${invalidBase64},${validBase64},${invalidBase64}`), null);
+        });
+
+        it('should return null when the leading chain entry is empty', () => {
+            const validBase64 = encodeAsCloudflare(testDer);
+
+            assert.equal(parseBase64Der(`,${validBase64}`), null);
+            assert.equal(parseBase64Der(`  ,${validBase64}`), null);
+        });
+
+        it('should ignore a trailing empty chain entry', () => {
+            const validBase64 = encodeAsCloudflare(testDer);
+            const cert = parseBase64Der(`${validBase64},`);
+
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+            assert.equal(cert.issuerCertificate, undefined);
         });
 
         it('should return null when only trailing certs in a chain are valid', () => {


### PR DESCRIPTION
- Follow-up to #187, which only covered leaves that still looked like a PEM frame or a base64 entry. `splitPemBlocks` skips text before the first BEGIN marker and `parseBase64Der` filtered empty entries before picking the leaf, so `GARBAGE\n<valid cert>` and `,<valid cert>` both authenticated as the later certificate.
- Non-whitespace ahead of the first PEM block rejects the blob; leading whitespace is still fine. Covers `url-pem`, `url-pem-aws`, and `xfcc` through the shared linker.
- The first comma-separated entry is no longer filtered away, so an empty leaf slot rejects the header. Trailing empty entries are still ignored.