### PR TITLE
fix(types): use ChainedPeerCertificate on the request and callbacks

### DIFF
--- a/lib/clientCertificateAuth.d.cts
+++ b/lib/clientCertificateAuth.d.cts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import type { Socket } from 'net';
 import type { PeerCertificate, DetailedPeerCertificate } from 'tls';
+import type { ChainedPeerCertificate } from './parsers.js';
 import type {
     ClientCertificateAuthOptions as EsmOptions,
     ValidationCallback as EsmValidationCallback,
@@ -56,7 +57,7 @@ export interface ClientCertRequest extends IncomingMessage {
      * Available after successful certificate extraction.
      * Contains issuerCertificate chain if includeChain option is true.
      */
-    clientCertificate?: PeerCertificate | DetailedPeerCertificate;
+    clientCertificate?: ChainedPeerCertificate;
 }
 
 /**
@@ -88,7 +89,7 @@ export interface ClientCertificateAuthOptions {
      * @param req - The HTTP request object
      */
     onAuthenticated?: (
-        cert: PeerCertificate | DetailedPeerCertificate,
+        cert: ChainedPeerCertificate,
         req: ClientCertRequest
     ) => void | Promise<void>;
 
@@ -100,14 +101,14 @@ export interface ClientCertificateAuthOptions {
      * @param reason - Why authentication was rejected
      */
     onRejected?: (
-        cert: PeerCertificate | DetailedPeerCertificate | null,
+        cert: ChainedPeerCertificate | null,
         req: ClientCertRequest,
         reason: string
     ) => void | Promise<void>;
 }
 
 export type ValidationCallback = (
-    cert: PeerCertificate | DetailedPeerCertificate,
+    cert: ChainedPeerCertificate,
     req?: ClientCertRequest
 ) => boolean | PromiseLike<boolean>;
 

--- a/lib/clientCertificateAuth.d.ts
+++ b/lib/clientCertificateAuth.d.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import type { Socket } from 'net';
 import type { PeerCertificate, DetailedPeerCertificate } from 'tls';
+import type { ChainedPeerCertificate } from './parsers.js';
 import type { CertificateSource, HeaderEncoding } from './parsers.js';
 
 export type { CertificateSource, HeaderEncoding };
@@ -54,7 +55,7 @@ export interface ClientCertRequest extends IncomingMessage {
      * Available after successful certificate extraction, before authorization callback.
      * Contains issuerCertificate chain if includeChain option is true.
      */
-    clientCertificate?: PeerCertificate | DetailedPeerCertificate;
+    clientCertificate?: ChainedPeerCertificate;
 }
 
 /**
@@ -127,7 +128,7 @@ export interface ClientCertificateAuthOptions {
      * @param req - The HTTP request object
      */
     onAuthenticated?: (
-        cert: PeerCertificate | DetailedPeerCertificate,
+        cert: ChainedPeerCertificate,
         req: ClientCertRequest
     ) => void | Promise<void>;
 
@@ -139,14 +140,14 @@ export interface ClientCertificateAuthOptions {
      * @param reason - Why authentication was rejected
      */
     onRejected?: (
-        cert: PeerCertificate | DetailedPeerCertificate | null,
+        cert: ChainedPeerCertificate | null,
         req: ClientCertRequest,
         reason: string
     ) => void | Promise<void>;
 }
 
 export type ValidationCallback = (
-    cert: PeerCertificate | DetailedPeerCertificate,
+    cert: ChainedPeerCertificate,
     req?: ClientCertRequest
 ) => boolean | PromiseLike<boolean>;
 

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -34,7 +34,7 @@ function normalizeCallbackError(err) {
 }
 
 /**
- * @typedef {import('http').IncomingMessage & { secure?: boolean; socket: import('net').Socket & { authorized?: boolean; authorizationError?: Error | string; getPeerCertificate?: (detailed?: boolean) => import('tls').PeerCertificate | import('tls').DetailedPeerCertificate }; clientCertificate?: import('tls').PeerCertificate }} ClientCertRequest
+ * @typedef {import('http').IncomingMessage & { secure?: boolean; socket: import('net').Socket & { authorized?: boolean; authorizationError?: Error | string; getPeerCertificate?: (detailed?: boolean) => import('tls').PeerCertificate | import('tls').DetailedPeerCertificate }; clientCertificate?: import('./parsers.js').ChainedPeerCertificate }} ClientCertRequest
  * @typedef {import('http').ServerResponse & { redirect: (statusOrUrl: number | string, url?: string) => void }} ClientCertResponse
  * @typedef {(req: ClientCertRequest, res: ClientCertResponse, next: (err?: Error) => void) => void} Middleware
  */
@@ -64,9 +64,9 @@ function normalizeCallbackError(err) {
  * @property {string} [verifyValue] - Expected value indicating successful verification (e.g., 'SUCCESS').
  *   If verifyHeader is set, requests are rejected unless the header matches this value.
  *   Comparison is exact (case-sensitive, no whitespace trimming); set this to the exact string your proxy emits.
- * @property {(cert: import('tls').PeerCertificate, req: ClientCertRequest) => void | Promise<void>} [onAuthenticated] -
+ * @property {(cert: import('./parsers.js').ChainedPeerCertificate, req: ClientCertRequest) => void | Promise<void>} [onAuthenticated] -
  *   Called when a client is successfully authenticated. Fire-and-forget.
- * @property {(cert: import('tls').PeerCertificate | null, req: ClientCertRequest, reason: string) => void | Promise<void>} [onRejected] -
+ * @property {(cert: import('./parsers.js').ChainedPeerCertificate | null, req: ClientCertRequest, reason: string) => void | Promise<void>} [onRejected] -
  *   Called when authentication is rejected. Fire-and-forget.
  */
 
@@ -78,7 +78,7 @@ function normalizeCallbackError(err) {
  * `req.socket.getPeerCertificate()` or extracted from headers) and must
  * return `true` (or a thenable resolving to `true`) for the request to proceed.
  *
- * @param {(cert: import('tls').PeerCertificate, req: ClientCertRequest) => boolean | PromiseLike<boolean>} callback
+ * @param {(cert: import('./parsers.js').ChainedPeerCertificate, req: ClientCertRequest) => boolean | PromiseLike<boolean>} callback
  *   Validation function that receives the client certificate and the request
  *   object. Returns true/false (sync) or a `PromiseLike<boolean>` (async,
  *   including native Promises and any thenable resolving to a boolean) to

--- a/test/test-typescript-types.ts
+++ b/test/test-typescript-types.ts
@@ -275,6 +275,23 @@ const _terminatingChain: ChainedPeerCertificate = {
     issuerCertificate: undefined,
 };
 
+// Test 27: chain access inside a validation callback and off req.clientCertificate
+// needs no narrowing when includeChain is set
+const _chainInCallback = clientCertificateAuth(
+    (cert) => cert.issuerCertificate?.subject?.CN === 'Intermediate CA',
+    { includeChain: true }
+);
+
+function readChainOffRequest(req: ClientCertRequest): string | string[] | undefined {
+    return req.clientCertificate?.issuerCertificate?.subject?.CN;
+}
+
+const _chainInHooks = clientCertificateAuth(() => true, {
+    includeChain: true,
+    onAuthenticated: (cert) => void cert.issuerCertificate?.subject,
+    onRejected: (cert) => void cert?.issuerCertificate?.subject,
+});
+
 // Suppress unused variable warnings - this file is for type-checking only
 void _statusCode;
 void _syncMiddleware;
@@ -308,3 +325,6 @@ void _chainHeaderOption;
 void _badNewSource;
 void testChainAccess;
 void _terminatingChain;
+void _chainInCallback;
+void readChainOffRequest;
+void _chainInHooks;


### PR DESCRIPTION
- `req.clientCertificate`, `ValidationCallback`, `onAuthenticated`, and `onRejected` still said `PeerCertificate | DetailedPeerCertificate`, so `cert.issuerCertificate` under a documented `includeChain: true` was a TS2339 on the middleware path while #188 made it work on the extractor path.
- Applied to the ESM declarations, the CJS declarations, and the JSDoc. `socket.getPeerCertificate` keeps Node's own signature.
- Type tests 27 cover all four surfaces; they fail with TS2339 against the previous declarations.