### PR TITLE
docs(reverse-proxy): document the leaf rule and single-header chain encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,8 @@ app.use(clientCertificateAuth((cert) => {
 
 When `includeChain: true`, the certificate object includes `issuerCertificate` linking to the issuer's certificate (and so on up the chain). This works consistently for both socket-based and header-based extraction.
 
+For header-based extraction the first certificate in the header is the leaf. If it is empty or unparseable the header is rejected with `header_missing_or_malformed` rather than promoting the next certificate into the leaf position. See [Reverse Proxy Setup](https://tgies.github.io/client-certificate-auth/guide/reverse-proxy#chains-in-a-single-header) for the per-encoding details.
+
 ### User Login
 
 Client certificates provide cryptographically-verified identity, making them ideal for user authentication. Map certificate fields to user accounts in your database:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -326,6 +326,8 @@ app.use(clientCertificateAuth((cert) => {
 
 When `includeChain: true`, the certificate object includes `issuerCertificate` linking to the issuer's certificate (and so on up the chain). This works consistently for both socket-based and header-based extraction.
 
+For header-based extraction the first certificate in the header is the leaf. If it is empty or unparseable the header is rejected with `header_missing_or_malformed` rather than promoting the next certificate into the leaf position. See [Chains in a Single Header](./reverse-proxy.md#chains-in-a-single-header) for the per-encoding details.
+
 ## User Login Patterns
 
 Client certificates provide cryptographically-verified identity, making them ideal for user authentication. Map certificate fields to user accounts in your database:

--- a/docs/guide/reverse-proxy.md
+++ b/docs/guide/reverse-proxy.md
@@ -129,6 +129,12 @@ The library supports five encoding formats covering all major reverse proxies:
 
 HAProxy's native certificate forwarding (`http-request set-header ... %[ssl_c_der,base64]`) is base64 DER, so pair it with `base64-der`. HAProxy has no built-in URL-encoded-PEM output; `url-pem` from HAProxy requires a custom Lua `url_enc` converter.
 
+### Chains in a Single Header
+
+`url-pem`, `url-pem-aws`, and `xfcc` accept concatenated PEM blocks in one header value; `base64-der` accepts comma-separated DER. The first entry is the leaf, and the leaf is the identity the request authenticates as.
+
+The leaf entry has to parse on its own. If it is empty, unparseable, or preceded by anything other than whitespace, the whole header is rejected and extraction fails with `header_missing_or_malformed`. A leaf damaged in transit therefore produces a 401 rather than authenticating the request as the next certificate in the header. Entries after the leaf are dropped individually when they fail to parse, and the chain links past them.
+
 ## Chain Header
 
 Some proxies forward the leaf certificate and the certificate chain in two separate headers. RFC 9440 is the canonical example: the leaf goes in `Client-Cert` and the chain in `Client-Cert-Chain` (a comma-separated structured-field list of `:base64:` items, leaf-nearest first).
@@ -151,7 +157,7 @@ app.use(clientCertificateAuth(checkAuth, {
 }));
 ```
 
-The comma splitting targets RFC 9440 structured-field lists. For non-RFC-9440 encodings that may contain commas inside a single cert value, use the single-header chain support already built into `base64-der` (comma-separated DER) and `url-pem-aws` (concatenated PEM blocks) instead.
+The comma splitting targets RFC 9440 structured-field lists. For non-RFC-9440 encodings that may contain commas inside a single cert value, use the single-header chain support built into `base64-der` (comma-separated DER), `url-pem` and `url-pem-aws` (concatenated PEM blocks), and `xfcc` (the `Chain` element) instead.
 
 ## Fallback Mode
 


### PR DESCRIPTION
- Adds `url-pem` (as of #188) and `xfcc`'s `Chain` element to the list of encodings with single-header chain support.
- New "Chains in a Single Header" section: the first entry is the leaf, and an empty, unparseable, or junk-prefixed leaf rejects the header instead of promoting the next certificate (#187, #189).
- README and getting-started chain sections point at it.