### PR TITLE
fix(parsers): reject headers whose leaf is missing or unparseable

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -123,6 +123,12 @@ function chainFromMultiBlockPem(pem) {
         return null;
     }
 
+    // Junk ahead of the leaf block means the leaf was damaged past recognition;
+    // the next block must not slide into its place. Leading whitespace is fine.
+    if (pem.slice(0, pem.indexOf(pemBlocks[0])).trim() !== '') {
+        return null;
+    }
+
     // An unparseable leaf rejects the whole blob. Promoting the next block
     // would authenticate the request as whichever certificate parsed first.
     let leaf;
@@ -277,16 +283,11 @@ export function parseBase64Der(headerValue) {
     }
 
     // Handle comma-separated cert chains (Traefik format)
-    // Stryker disable next-line MethodExpression: .trim() no-op (base64 ignores whitespace); .filter(Boolean) redundant (empty strings throw in X509Certificate, caught below)
-    const certParts = headerValue.split(',').map(s => s.trim()).filter(Boolean);
+    // Stryker disable next-line MethodExpression: .trim() no-op (base64 ignores whitespace)
+    const certParts = headerValue.split(',').map(s => s.trim());
 
-    // Stryker disable next-line BlockStatement,ConditionalExpression: →false equivalent (empty array → undefined leaf → derToCertificate throws for the same null); →true killed by valid base64-der tests
-    if (certParts.length === 0) {
-        return null;
-    }
-
-    // An unparseable leaf rejects the whole header. Promoting the next entry
-    // would authenticate the request as whichever certificate parsed first.
+    // An empty or unparseable leaf rejects the whole header. Promoting the next
+    // entry would authenticate the request as whichever certificate parsed first.
     let leaf;
     try {
         leaf = derToCertificate(Buffer.from(certParts[0], 'base64'));

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -103,8 +103,9 @@ function splitPemBlocks(pem) {
 
 /**
  * Parse a multi-block PEM blob into a chained PeerCertificate. Splits the
- * input into individual blocks, parses each, drops blocks that fail to
- * parse, and links the remainder via issuerCertificate.
+ * input into individual blocks and links them via issuerCertificate. The
+ * first block is the leaf and must parse; later blocks that fail to parse
+ * are dropped and the chain links past them.
  *
  * Used by parsers whose proxies forward the full chain in a single field
  * (parseUrlPemAws, parseXfcc Chain). Without explicit chain linking, calling
@@ -117,22 +118,27 @@ function splitPemBlocks(pem) {
  */
 function chainFromMultiBlockPem(pem) {
     const pemBlocks = splitPemBlocks(pem);
-    // Stryker disable next-line BlockStatement,ConditionalExpression: short-circuit; falling through hits the next certs.length===0 check with the same null result
+    // Stryker disable next-line BlockStatement,ConditionalExpression: short-circuit; falling through hands undefined to pemToCertificate, which throws for the same null result
     if (pemBlocks.length === 0) {
         return null;
     }
 
-    const certs = pemBlocks.map(block => {
-        try {
-            return pemToCertificate(block);
-        } catch {
-            // Stryker disable next-line BlockStatement: empty catch returns undefined which .filter(Boolean) drops alongside null — same chain output
-            return null;
-        }
-    }).filter(Boolean);
-
-    if (certs.length === 0) {
+    // An unparseable leaf rejects the whole blob. Promoting the next block
+    // would authenticate the request as whichever certificate parsed first.
+    let leaf;
+    try {
+        leaf = pemToCertificate(pemBlocks[0]);
+    } catch {
         return null;
+    }
+
+    const certs = [leaf];
+    for (const block of pemBlocks.slice(1)) {
+        try {
+            certs.push(pemToCertificate(block));
+        } catch {
+            // Dropped; the chain links past it.
+        }
     }
 
     // Stryker disable next-line EqualityOperator: setting issuerCertificate = undefined on last cert is same as not setting it
@@ -274,24 +280,27 @@ export function parseBase64Der(headerValue) {
     // Stryker disable next-line MethodExpression: .trim() no-op (base64 ignores whitespace); .filter(Boolean) redundant (empty strings throw in X509Certificate, caught below)
     const certParts = headerValue.split(',').map(s => s.trim()).filter(Boolean);
 
-    // Stryker disable next-line BlockStatement,ConditionalExpression: →false equivalent (empty array → zero certs → certs.length===0 catches it); →true killed by valid base64-der tests
+    // Stryker disable next-line BlockStatement,ConditionalExpression: →false equivalent (empty array → undefined leaf → derToCertificate throws for the same null); →true killed by valid base64-der tests
     if (certParts.length === 0) {
         return null;
     }
 
-    // Parse all certs in the chain
-    const certs = certParts.map(base64 => {
-        try {
-            const derBuffer = Buffer.from(base64, 'base64');
-            return derToCertificate(derBuffer);
-        } catch {
-            // Equivalent mutant (undefined also filtered by .filter(Boolean)) — catch-body BlockStatement unsuppressible via Stryker comments
-            return null;
-        }
-    }).filter(Boolean);
-
-    if (certs.length === 0) {
+    // An unparseable leaf rejects the whole header. Promoting the next entry
+    // would authenticate the request as whichever certificate parsed first.
+    let leaf;
+    try {
+        leaf = derToCertificate(Buffer.from(certParts[0], 'base64'));
+    } catch {
         return null;
+    }
+
+    const certs = [leaf];
+    for (const base64 of certParts.slice(1)) {
+        try {
+            certs.push(derToCertificate(Buffer.from(base64, 'base64')));
+        } catch {
+            // Dropped; the chain links past it.
+        }
     }
 
     // Link the cert chain via issuerCertificate

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -171,6 +171,15 @@ describe('parsers module', () => {
             assert.equal(cert.subject.CN, 'Test Parser Client');
         });
 
+        it('should return null when the leading PEM block is malformed', () => {
+            // The leaf must parse on its own; the valid block behind it is not
+            // promoted into the leaf position.
+            const invalidBlock = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64\n-----END CERTIFICATE-----\n';
+            const encoded = encodeAsAwsAlb(invalidBlock + testPem);
+
+            assert.equal(parseUrlPemAws(encoded), null);
+        });
+
         it('should return null when every PEM block in a chain is malformed', () => {
             const invalidBlock1 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_1\n-----END CERTIFICATE-----\n';
             const invalidBlock2 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_2\n-----END CERTIFICATE-----\n';
@@ -430,6 +439,13 @@ describe('parsers module', () => {
             assert.equal(cert.issuerCertificate.subject.CN, 'Test Intermediate');
         });
 
+        it('should return null when the leading block in multi-block Chain is malformed', () => {
+            const invalidBlock = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64\n-----END CERTIFICATE-----\n';
+            const xfcc = `Hash=abc;Chain="${encodeURIComponent(invalidBlock + testPem)}"`;
+
+            assert.equal(parseXfcc(xfcc), null);
+        });
+
         it('should return null when every block in multi-block Chain is invalid', () => {
             const invalidBlock1 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_1\n-----END CERTIFICATE-----\n';
             const invalidBlock2 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_2\n-----END CERTIFICATE-----\n';
@@ -522,15 +538,20 @@ describe('parsers module', () => {
                 'only two valid certs in chain, not three');
         });
 
-        it('should return single valid cert when others in chain are invalid', () => {
+        it('should return null when the leading cert in a chain is invalid', () => {
             const validBase64 = encodeAsCloudflare(testDer);
             const invalidBase64 = Buffer.from('invalid-cert-data').toString('base64');
 
-            const result = parseBase64Der(`${invalidBase64},${validBase64},${invalidBase64}`);
-            assert.ok(result);
-            assert.equal(result.subject.CN, 'Test Parser Client');
-            assert.equal(result.issuerCertificate, undefined,
-                'single surviving cert should not have issuerCertificate');
+            // The leaf is the identity the request authenticates as, so a
+            // later entry must never be promoted into its place.
+            assert.equal(parseBase64Der(`${invalidBase64},${validBase64},${invalidBase64}`), null);
+        });
+
+        it('should return null when only trailing certs in a chain are valid', () => {
+            const validBase64 = encodeAsCloudflare(testDer);
+            const invalidBase64 = Buffer.from('invalid-cert-data').toString('base64');
+
+            assert.equal(parseBase64Der(`${invalidBase64},${validBase64}`), null);
         });
     });
 

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -180,6 +180,14 @@ describe('parsers module', () => {
             assert.equal(parseUrlPemAws(encoded), null);
         });
 
+        it('should return null when junk precedes the first PEM block', () => {
+            // A leaf mangled past its markers is not a block at all, so the
+            // next certificate would otherwise take the leaf position.
+            const encoded = encodeAsAwsAlb(`GARBAGE TEXT\n${testPem}`);
+
+            assert.equal(parseUrlPemAws(encoded), null);
+        });
+
         it('should return null when every PEM block in a chain is malformed', () => {
             const invalidBlock1 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_1\n-----END CERTIFICATE-----\n';
             const invalidBlock2 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_2\n-----END CERTIFICATE-----\n';
@@ -446,6 +454,12 @@ describe('parsers module', () => {
             assert.equal(parseXfcc(xfcc), null);
         });
 
+        it('should return null when junk precedes the first block in Chain', () => {
+            const xfcc = `Hash=abc;Chain="${encodeURIComponent(`GARBAGE TEXT\n${testPem}`)}"`;
+
+            assert.equal(parseXfcc(xfcc), null);
+        });
+
         it('should return null when every block in multi-block Chain is invalid', () => {
             const invalidBlock1 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_1\n-----END CERTIFICATE-----\n';
             const invalidBlock2 = '-----BEGIN CERTIFICATE-----\nNOT_VALID_BASE64_2\n-----END CERTIFICATE-----\n';
@@ -545,6 +559,22 @@ describe('parsers module', () => {
             // The leaf is the identity the request authenticates as, so a
             // later entry must never be promoted into its place.
             assert.equal(parseBase64Der(`${invalidBase64},${validBase64},${invalidBase64}`), null);
+        });
+
+        it('should return null when the leading chain entry is empty', () => {
+            const validBase64 = encodeAsCloudflare(testDer);
+
+            assert.equal(parseBase64Der(`,${validBase64}`), null);
+            assert.equal(parseBase64Der(`  ,${validBase64}`), null);
+        });
+
+        it('should ignore a trailing empty chain entry', () => {
+            const validBase64 = encodeAsCloudflare(testDer);
+            const cert = parseBase64Der(`${validBase64},`);
+
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+            assert.equal(cert.issuerCertificate, undefined);
         });
 
         it('should return null when only trailing certs in a chain are valid', () => {


### PR DESCRIPTION
Backport of #187 and #189 to the 1.x line.

- `chainFromMultiBlockPem` and `parseBase64Der` dropped unparseable entries before picking the leaf, so an empty, mangled, or junk-prefixed first entry let the next certificate become the authenticated identity. Affects `url-pem-aws`, `xfcc`, and `base64-der`.
- `url-pem` on 1.x parses a single block and never linked chains, so the url-pem half of #188/#189 does not apply.
- Tests are the parser-level ones from both PRs. The extractor-level test from #189 is omitted: 1.x extractor tests use placeholder header strings rather than real DER fixtures.