### PR TITLE
ci: bump codecov-action to v7 on the maintenance branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           path: coverage/
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           use_oidc: true
           fail_ci_if_error: true


### PR DESCRIPTION
The pinned v6.0.0 downloads a Codecov CLI whose GPG signature no longer verifies, failing Upload Coverage on every PR into `maint/1.x`. Master already uses v7.0.0.