### PR TITLE
fix(middleware): keep next(err) reachable when the callback throws a frozen error

### DIFF
--- a/lib/clientCertificateAuth.cjs
+++ b/lib/clientCertificateAuth.cjs
@@ -33,16 +33,47 @@ function isThenable(value) {
 }
 
 /**
- * Wrap primitive values thrown or rejected by the validation callback in an
- * Error so `.message` and `.status` access is safe; objects pass through.
+ * Read `.message` without trusting the object: accessor traps and
+ * non-string values yield an empty string.
+ * @param {any} error
+ * @returns {string}
+ */
+function errorMessage(error) {
+    try {
+        const message = error.message;
+        return typeof message === 'string' ? message : '';
+    } catch {
+        return '';
+    }
+}
+
+/**
+ * Wrap primitives thrown by the validation callback in an Error and default
+ * `status` to 401. Objects that refuse the assignment or throw from their
+ * accessors (frozen, sealed, getter-only or trapped `status`) are replaced
+ * by a new Error carrying them as `cause`.
  * @param {unknown} err
  * @returns {any}
  */
 function normalizeCallbackError(err) {
-    if (err !== null && (typeof err === 'object' || typeof err === 'function')) {
-        return err;
+    const error = err !== null && (typeof err === 'object' || typeof err === 'function')
+        ? err
+        : new Error(err === null || err === undefined ? '' : String(err));
+    let usable;
+    try {
+        if (error.status === undefined) {
+            error.status = 401;
+        }
+        usable = error.status !== undefined;
+    } catch {
+        usable = false;
     }
-    return new Error(err === null || err === undefined ? '' : String(err));
+    if (usable) {
+        return error;
+    }
+    const wrapped = new Error(errorMessage(error), { cause: error });
+    wrapped.status = 401;
+    return wrapped;
 }
 
 /**
@@ -160,10 +191,7 @@ function clientCertificateAuth(callback, options = {}) {
             if (isThenable(result)) {
                 Promise.resolve(result).then(doneAuthorizing).catch((rejection) => {
                     const err = normalizeCallbackError(rejection);
-                    safeCallHook(onRejected, cert, req, err.message || 'callback_threw');
-                    if (err.status === undefined) {
-                        err.status = 401;
-                    }
+                    safeCallHook(onRejected, cert, req, errorMessage(err) || 'callback_threw');
                     next(err);
                 });
             } else {
@@ -171,10 +199,7 @@ function clientCertificateAuth(callback, options = {}) {
             }
         } catch (thrown) {
             const err = normalizeCallbackError(thrown);
-            safeCallHook(onRejected, cert, req, err.message || 'callback_threw');
-            if (err.status === undefined) {
-                err.status = 401;
-            }
+            safeCallHook(onRejected, cert, req, errorMessage(err) || 'callback_threw');
             next(err);
         }
     };

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -21,16 +21,48 @@ function isThenable(value) {
 }
 
 /**
- * Wrap primitive values thrown or rejected by the validation callback in an
- * Error so `.message` and `.status` access is safe; objects pass through.
+ * Read `.message` without trusting the object: accessor traps and
+ * non-string values yield an empty string.
+ * @param {any} error
+ * @returns {string}
+ */
+function errorMessage(error) {
+  try {
+    const message = error.message;
+    return typeof message === 'string' ? message : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Wrap primitives thrown by the validation callback in an Error and default
+ * `status` to 401. Objects that refuse the assignment or throw from their
+ * accessors (frozen, sealed, getter-only or trapped `status`) are replaced
+ * by a new Error carrying them as `cause`.
  * @param {unknown} err
  * @returns {any}
  */
 function normalizeCallbackError(err) {
-  if (err !== null && (typeof err === 'object' || typeof err === 'function')) {
-    return err;
+  /** @type {any} */
+  const error = err !== null && (typeof err === 'object' || typeof err === 'function')
+    ? err
+    : new Error(err === null || err === undefined ? '' : String(err));
+  let usable;
+  try {
+    if (error.status === undefined) {
+      error.status = 401;
+    }
+    usable = error.status !== undefined;
+  } catch {
+    usable = false;
   }
-  return new Error(err === null || err === undefined ? '' : String(err));
+  if (usable) {
+    return error;
+  }
+  const wrapped = new Error(errorMessage(error), { cause: error });
+  wrapped.status = 401;
+  return wrapped;
 }
 
 /**
@@ -210,10 +242,7 @@ export default function clientCertificateAuth(callback, options = {}) {
       if (isThenable(callbackResult)) {
         Promise.resolve(callbackResult).then(doneAuthorizing).catch((rejection) => {
           const err = normalizeCallbackError(rejection);
-          safeCallHook(onRejected, cert, req, err.message || 'callback_threw');
-          if (err.status === undefined) {
-            err.status = 401;
-          }
+          safeCallHook(onRejected, cert, req, errorMessage(err) || 'callback_threw');
           next(err);
         });
       } else {
@@ -221,10 +250,7 @@ export default function clientCertificateAuth(callback, options = {}) {
       }
     } catch (thrown) {
       const err = normalizeCallbackError(thrown);
-      safeCallHook(onRejected, cert, req, err.message || 'callback_threw');
-      if (err.status === undefined) {
-        err.status = 401;
-      }
+      safeCallHook(onRejected, cert, req, errorMessage(err) || 'callback_threw');
       next(err);
     }
   };

--- a/test/test-unit-clientCertificateAuth.cjs
+++ b/test/test-unit-clientCertificateAuth.cjs
@@ -330,6 +330,123 @@ describe('clientCertificateAuth (CommonJS)', () => {
                     done();
                 });
             });
+
+            it('should pass a frozen sync error to next() with status 401', done => {
+                const locked = Object.freeze(new Error('locked'));
+                const middleware = clientCertificateAuth(() => {
+                    throw locked;
+                });
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.message, 'locked');
+                    assert.equal(err.status, 401);
+                    assert.equal(err.cause, locked);
+                    done();
+                });
+            });
+
+            it('should pass a frozen async rejection to next() with status 401', done => {
+                const locked = Object.freeze(new Error('locked'));
+                const middleware = clientCertificateAuth(async () => {
+                    throw locked;
+                });
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.message, 'locked');
+                    assert.equal(err.status, 401);
+                    assert.equal(err.cause, locked);
+                    done();
+                });
+            });
+
+            it('should pass a frozen error with a pre-set status through unchanged', done => {
+                const forbidden = new Error('Custom forbidden');
+                forbidden.status = 403;
+                Object.freeze(forbidden);
+                const middleware = clientCertificateAuth(() => {
+                    throw forbidden;
+                });
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.equal(err, forbidden);
+                    assert.equal(err.status, 403);
+                    done();
+                });
+            });
+
+            it('should wrap a frozen non-Error object with an empty message', done => {
+                const thrown = Object.freeze({ code: 'E_LOCKED' });
+                const middleware = clientCertificateAuth(() => {
+                    throw thrown;
+                });
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.message, '');
+                    assert.equal(err.status, 401);
+                    assert.equal(err.cause, thrown);
+                    done();
+                });
+            });
+
+            it('should wrap a sync error whose accessors throw', done => {
+                const trap = { get status() { throw new Error('status trap'); }, get message() { throw new Error('message trap'); } };
+                const middleware = clientCertificateAuth(() => {
+                    throw trap;
+                });
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.message, '');
+                    assert.equal(err.status, 401);
+                    assert.equal(err.cause, trap);
+                    done();
+                });
+            });
+
+            it('should wrap a sync error whose status assignment is silently dropped', done => {
+                const dropped = new Proxy(new Error('dropped'), { set: () => true });
+                const middleware = clientCertificateAuth(() => {
+                    throw dropped;
+                });
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.message, 'dropped');
+                    assert.equal(err.status, 401);
+                    assert.equal(err.cause, dropped);
+                    done();
+                });
+            });
+
+            it('should wrap an async rejection whose accessors throw', done => {
+                const trap = { get status() { throw new Error('status trap'); }, get message() { throw new Error('message trap'); } };
+                const middleware = clientCertificateAuth(async () => {
+                    throw trap;
+                });
+                middleware(mockGoodReq, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.message, '');
+                    assert.equal(err.status, 401);
+                    assert.equal(err.cause, trap);
+                    done();
+                });
+            });
+
+            it('should report callback_threw when the thrown message is unreadable or not a string', async () => {
+                for (const thrown of [{ get message() { throw new Error('message trap'); } }, { message: 42 }]) {
+                    let reason = null;
+                    const middleware = clientCertificateAuth(() => {
+                        throw thrown;
+                    }, {
+                        onRejected: (cert, req, why) => { reason = why; }
+                    });
+                    await new Promise(resolve => {
+                        middleware(mockGoodReq, mockRes, (err) => {
+                            assert.equal(err, thrown);
+                            assert.equal(err.status, 401);
+                            setImmediate(resolve);
+                        });
+                    });
+                    assert.equal(reason, 'callback_threw');
+                }
+            });
         });
 
         describe('when the client certificate does not validate', () => {

--- a/test/test-unit-clientCertificateAuth.js
+++ b/test/test-unit-clientCertificateAuth.js
@@ -335,6 +335,123 @@ describe('clientCertificateAuth', () => {
           done();
         });
       });
+
+      it('should pass a frozen sync error to next() with status 401', done => {
+        const locked = Object.freeze(new Error('locked'));
+        const middleware = clientCertificateAuth(() => {
+          throw locked;
+        });
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.message, 'locked');
+          assert.equal(err.status, 401);
+          assert.equal(err.cause, locked);
+          done();
+        });
+      });
+
+      it('should pass a frozen async rejection to next() with status 401', done => {
+        const locked = Object.freeze(new Error('locked'));
+        const middleware = clientCertificateAuth(async () => {
+          throw locked;
+        });
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.message, 'locked');
+          assert.equal(err.status, 401);
+          assert.equal(err.cause, locked);
+          done();
+        });
+      });
+
+      it('should pass a frozen error with a pre-set status through unchanged', done => {
+        const forbidden = new Error('Custom forbidden');
+        forbidden.status = 403;
+        Object.freeze(forbidden);
+        const middleware = clientCertificateAuth(() => {
+          throw forbidden;
+        });
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.equal(err, forbidden);
+          assert.equal(err.status, 403);
+          done();
+        });
+      });
+
+      it('should wrap a frozen non-Error object with an empty message', done => {
+        const thrown = Object.freeze({ code: 'E_LOCKED' });
+        const middleware = clientCertificateAuth(() => {
+          throw thrown;
+        });
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.message, '');
+          assert.equal(err.status, 401);
+          assert.equal(err.cause, thrown);
+          done();
+        });
+      });
+
+      it('should wrap a sync error whose accessors throw', done => {
+        const trap = { get status() { throw new Error('status trap'); }, get message() { throw new Error('message trap'); } };
+        const middleware = clientCertificateAuth(() => {
+          throw trap;
+        });
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.message, '');
+          assert.equal(err.status, 401);
+          assert.equal(err.cause, trap);
+          done();
+        });
+      });
+
+      it('should wrap a sync error whose status assignment is silently dropped', done => {
+        const dropped = new Proxy(new Error('dropped'), { set: () => true });
+        const middleware = clientCertificateAuth(() => {
+          throw dropped;
+        });
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.message, 'dropped');
+          assert.equal(err.status, 401);
+          assert.equal(err.cause, dropped);
+          done();
+        });
+      });
+
+      it('should wrap an async rejection whose accessors throw', done => {
+        const trap = { get status() { throw new Error('status trap'); }, get message() { throw new Error('message trap'); } };
+        const middleware = clientCertificateAuth(async () => {
+          throw trap;
+        });
+        middleware(mockGoodReq, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.message, '');
+          assert.equal(err.status, 401);
+          assert.equal(err.cause, trap);
+          done();
+        });
+      });
+
+      it('should report callback_threw when the thrown message is unreadable or not a string', async () => {
+        for (const thrown of [{ get message() { throw new Error('message trap'); } }, { message: 42 }]) {
+          let reason = null;
+          const middleware = clientCertificateAuth(() => {
+            throw thrown;
+          }, {
+            onRejected: (cert, req, why) => { reason = why; }
+          });
+          await new Promise(resolve => {
+            middleware(mockGoodReq, mockRes, (err) => {
+              assert.equal(err, thrown);
+              assert.equal(err.status, 401);
+              setImmediate(resolve);
+            });
+          });
+          assert.equal(reason, 'callback_threw');
+        }
+      });
     });
 
     describe('when the client certificate does not validate', () => {


### PR DESCRIPTION
A frozen, sealed, or accessor-trapping error thrown by the validation callback now reaches next(err) with status 401 instead of escaping the middleware.