### PR TITLE
fix(extractor): report unreadable request headers instead of throwing

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Framework-agnostic certificate extraction function exported from `client-certifi
 | Name | Type | Description |
 |------|------|-------------|
 | `req` | `Object` | Request object with `headers` and optional `socket` |
-| `req.headers` | `Record<string, string \| string[]>` | HTTP headers object |
+| `req.headers` | `Record<string, string \| string[]>` | Optional. HTTP headers object; a missing or unreadable one counts as no headers |
 | `req.socket` | `Object` | Optional TLS socket (for socket-based extraction) |
 | `options` | `Object` | Same options as middleware (except `onAuthenticated`/`onRejected`) |
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -211,7 +211,7 @@ Framework-agnostic certificate extraction function exported from `client-certifi
 | Name | Type | Description |
 |------|------|-------------|
 | `req` | `Object` | Request object with `headers` and optional `socket` |
-| `req.headers` | `Record<string, string \| string[]>` | HTTP headers object |
+| `req.headers` | `Record<string, string \| string[]>` | Optional. HTTP headers object; a missing or unreadable one counts as no headers |
 | `req.socket` | `Object` | Optional TLS socket (for socket-based extraction) |
 | `options` | `Object` | Same options as middleware (except `onAuthenticated`/`onRejected`) |
 

--- a/lib/extractor.d.ts
+++ b/lib/extractor.d.ts
@@ -28,8 +28,10 @@
  * extraction (direct TLS connections). Returns a structured result object instead of
  * throwing or using callbacks, making it suitable for any framework adapter.
  *
- * @param {Object} req - Request object with headers and optional socket
- * @param {Record<string, string | string[] | undefined>} req.headers - HTTP headers object
+ * @param {Object} req - Request object with headers and optional socket. A missing or
+ *   non-object `headers` field, one whose accessor throws, and one holding a
+ *   property whose accessor throws are all treated as having no headers.
+ * @param {Record<string, string | string[] | undefined>} [req.headers] - HTTP headers object
  * @param {Object} [req.socket] - TLS socket with getPeerCertificate() method
  * @param {boolean} [req.socket.authorized] - Whether socket was authorized
  * @param {(detailed: boolean) => import('tls').PeerCertificate} [req.socket.getPeerCertificate] - Get peer certificate
@@ -53,7 +55,7 @@
  * });
  */
 export function extractClientCertificate(req: {
-    headers: Record<string, string | string[] | undefined>;
+    headers?: Record<string, string | string[] | undefined>;
     socket?: {
         authorized?: boolean;
         getPeerCertificate?: (detailed: boolean) => import("tls").PeerCertificate;

--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -92,8 +92,10 @@ export function validateExtractorOptions(options = {}) {
  * extraction (direct TLS connections). Returns a structured result object instead of
  * throwing or using callbacks, making it suitable for any framework adapter.
  *
- * @param {Object} req - Request object with headers and optional socket
- * @param {Record<string, string | string[] | undefined>} req.headers - HTTP headers object
+ * @param {Object} req - Request object with headers and optional socket. A missing or
+ *   non-object `headers` field, one whose accessor throws, and one holding a
+ *   property whose accessor throws are all treated as having no headers.
+ * @param {Record<string, string | string[] | undefined>} [req.headers] - HTTP headers object
  * @param {Object} [req.socket] - TLS socket with getPeerCertificate() method
  * @param {boolean} [req.socket.authorized] - Whether socket was authorized
  * @param {(detailed: boolean) => import('tls').PeerCertificate} [req.socket.getPeerCertificate] - Get peer certificate
@@ -135,10 +137,26 @@ export function extractClientCertificate(req, options = {}) {
 
   // Try header-based extraction first if configured
   if (useHeaders) {
+    // Read once into a null-prototype map: a throwing accessor fails here
+    // rather than at whichever lookup reaches it.
+    /** @type {Record<string, string | string[] | undefined>} */
+    let headers = Object.create(null);
+    try {
+      const supplied = req?.headers;
+      if (supplied !== null && typeof supplied === 'object') {
+        for (const name of Object.keys(supplied)) {
+          headers[name] = supplied[name];
+        }
+      }
+    } catch {
+      // Unreadable headers count as none; a partial read is discarded.
+      headers = Object.create(null);
+    }
+
     // Verify upstream proxy's certificate validation if configured
     // Stryker disable next-line LogicalOperator: construction-time validation ensures both set or neither, single-side check is redundant but clearer
     if (verifyHeader && verifyValue) {
-      const verifyStatus = req.headers[verifyHeader.toLowerCase()];
+      const verifyStatus = headers[verifyHeader.toLowerCase()];
       if (Array.isArray(verifyStatus) || verifyStatus !== verifyValue) {
         return {
           success: false,
@@ -148,7 +166,7 @@ export function extractClientCertificate(req, options = {}) {
       }
     }
 
-    cert = getCertificateFromHeaders(req.headers, {
+    cert = getCertificateFromHeaders(headers, {
       certificateSource,
       certificateHeader,
       headerEncoding,
@@ -162,7 +180,7 @@ export function extractClientCertificate(req, options = {}) {
       const chainHeaderName = (chainHeader ?? preset?.chainHeader)?.toLowerCase();
       const chainEncoding = headerEncoding ?? preset?.encoding;
       if (chainHeaderName && chainEncoding) {
-        const chainHeaderValue = req.headers[chainHeaderName];
+        const chainHeaderValue = headers[chainHeaderName];
         // Only a non-empty string is parseable; anything else leaves the leaf unchained.
         if (typeof chainHeaderValue === 'string' && chainHeaderValue) {
           const chainCerts = chainHeaderValue
@@ -201,7 +219,7 @@ export function extractClientCertificate(req, options = {}) {
   // Fallback to socket-based extraction (original behavior)
   if (!cert) {
     // Ensure that the certificate was validated at the protocol level
-    if (!req.socket?.authorized) {
+    if (!req?.socket?.authorized) {
       return {
         success: false,
         certificate: null,

--- a/lib/fetch.d.ts
+++ b/lib/fetch.d.ts
@@ -12,14 +12,16 @@ import type { ExtractorOptions, ExtractionResult } from './extractor.js';
  * all work without modification.
  */
 export interface RequestLike {
-    headers: Iterable<[string, string]>;
+    /** Missing, non-iterable, and unreadable headers count as no headers. */
+    headers?: Iterable<[string, string]>;
 }
 
 /**
  * Extract a client certificate from a Web standard `Request` or any
  * object with iterable headers. Header-only (no TLS socket in Web Request).
  *
- * @param request - A Web Request or any object with iterable headers
+ * @param request - A Web Request or any object with iterable headers. Missing or
+ *   non-iterable headers, and entries that are not `[name, value]` tuples, are ignored.
  * @param options - Same options as `extractClientCertificate`. Header options only.
  */
 export declare function extractClientCertificateFromRequest(

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -19,7 +19,8 @@ import { extractClientCertificate } from './extractor.js';
  * `extractClientCertificate`. Header-only: Web `Request` has no TLS socket,
  * so `fallbackToSocket` is stripped and has no effect.
  *
- * @param {{ headers: Iterable<[string, string]> }} request - A Web Request or any object whose `headers` iterates `[name, value]` pairs.
+ * @param {{ headers?: Iterable<[string, string]> }} request - A Web Request or any object whose `headers` iterates `[name, value]` pairs.
+ *   Missing or non-iterable headers, and entries that are not `[name, value]` tuples, are ignored.
  * @param {ExtractorOptions} [options={}] - Same options as `extractClientCertificate`. Header-extraction options only; socket options are ignored.
  * @returns {ExtractionResult}
  *
@@ -48,9 +49,26 @@ import { extractClientCertificate } from './extractor.js';
 export function extractClientCertificateFromRequest(request, options = {}) {
   // Web Headers normalizes to lowercase, but Map and other iterables
   // preserve casing. Normalize here for the core extractor's lowercase lookup.
-  const headers = Object.create(null);
-  for (const [name, value] of request.headers) {
-    headers[name.toLowerCase()] = value;
+  let headers = Object.create(null);
+  try {
+    const supplied = /** @type {any} */ (request?.headers);
+    if (typeof supplied?.[Symbol.iterator] === 'function') {
+      for (const entry of supplied) {
+        if (!Array.isArray(entry) || entry.length !== 2) {
+          continue;
+        }
+        // Read once: an accessor could otherwise pass the check below and
+        // hand the assignment something else.
+        const [name, value] = entry;
+        if (typeof name !== 'string' || typeof value !== 'string') {
+          continue;
+        }
+        headers[name.toLowerCase()] = value;
+      }
+    }
+  } catch {
+    // A throwing iterator or accessor leaves a partial read. Discard it.
+    headers = Object.create(null);
   }
 
   const { fallbackToSocket: _ignored, ...rest } = options;

--- a/test/test-unit-extractor.js
+++ b/test/test-unit-extractor.js
@@ -192,6 +192,93 @@ describe('extractClientCertificate', () => {
     });
   });
 
+  describe('unreadable request headers', () => {
+    const cases = [
+      ['an undefined req', undefined],
+      ['a req without headers', {}],
+      ['null headers', { headers: null }],
+      ['string headers', { headers: 'x-amzn-mtls-clientcert=abc' }],
+      ['a throwing headers accessor', { get headers() { throw new Error('accessor threw'); } }],
+      ['a throwing certificate header accessor', {
+        headers: { get 'x-amzn-mtls-clientcert'() { throw new Error('header trap'); } },
+      }],
+      ['headers whose keys cannot be enumerated', {
+        headers: new Proxy({}, { ownKeys() { throw new Error('ownKeys threw'); } }),
+      }],
+    ];
+
+    for (const [label, req] of cases) {
+      it(`should report header_missing_or_malformed for ${label}`, () => {
+        const result = extractClientCertificate(req, { certificateSource: 'aws-alb' });
+
+        assert.strictEqual(result.success, false);
+        assert.strictEqual(result.certificate, null);
+        assert.strictEqual(result.reason, 'header_missing_or_malformed');
+      });
+    }
+
+    it('should report verification_header_mismatch when a verify header is configured', () => {
+      const result = extractClientCertificate({}, {
+        certificateSource: 'aws-alb',
+        verifyHeader: 'X-SSL-Client-Verify',
+        verifyValue: 'SUCCESS',
+      });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'verification_header_mismatch');
+    });
+
+    it('should discard every header when an unrelated accessor throws', () => {
+      const req = {
+        headers: {
+          'x-amzn-mtls-clientcert': encodeURIComponent(testPem),
+          get 'user-agent'() { throw new Error('header trap'); },
+        },
+      };
+
+      const result = extractClientCertificate(req, { certificateSource: 'aws-alb' });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'header_missing_or_malformed');
+    });
+
+    it('should report verification_header_mismatch when the verify header accessor throws', () => {
+      const result = extractClientCertificate({
+        headers: { get 'x-ssl-client-verify'() { throw new Error('verify trap'); } },
+      }, {
+        certificateSource: 'aws-alb',
+        verifyHeader: 'X-SSL-Client-Verify',
+        verifyValue: 'SUCCESS',
+      });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'verification_header_mismatch');
+    });
+
+    it('should fall back to the socket when fallbackToSocket is true', () => {
+      const mockCert = getMockPeerCertificate();
+      const req = {
+        headers: null,
+        socket: { authorized: true, getPeerCertificate: () => mockCert },
+      };
+
+      const result = extractClientCertificate(req, {
+        certificateSource: 'aws-alb',
+        fallbackToSocket: true,
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.deepStrictEqual(result.certificate, mockCert);
+    });
+
+    it('should report socket_not_authorized for an undefined req in socket mode', () => {
+      const result = extractClientCertificate(undefined);
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'socket_not_authorized');
+    });
+  });
+
   describe('socket extraction', () => {
     it('should extract certificate from authorized socket', () => {
       const mockCert = getMockPeerCertificate();

--- a/test/test-unit-fetch.js
+++ b/test/test-unit-fetch.js
@@ -244,6 +244,104 @@ describe('extractClientCertificateFromRequest', () => {
       assert.strictEqual(result.success, true);
       assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
     });
+
+    it('should ignore malformed tuples so they do not overwrite a valid value', () => {
+      for (const malformed of [['client-cert'], ['client-cert', 42], ['client-cert', 'x', 'y']]) {
+        const headers = [
+          ['client-cert', encodeAsRfc9440(testDer)],
+          malformed,
+        ];
+        const result = extractClientCertificateFromRequest({ headers }, {
+          certificateSource: 'cloudflare-rfc9440',
+        });
+        assert.strictEqual(result.success, true);
+        assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
+      }
+    });
+
+    it('should report a failure when the headers iterator throws mid-iteration', () => {
+      const throwing = {
+        *[Symbol.iterator]() {
+          yield ['client-cert', encodeAsRfc9440(testDer)];
+          throw new Error('iterator blew up');
+        },
+      };
+      const result = extractClientCertificateFromRequest({ headers: throwing }, {
+        certificateSource: 'cloudflare-rfc9440',
+      });
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'header_missing_or_malformed');
+    });
+
+    it('should report a failure when the headers iterator violates the protocol', () => {
+      const badProtocol = {
+        [Symbol.iterator]() {
+          return { next() { return 42; } };
+        },
+      };
+      const result = extractClientCertificateFromRequest({ headers: badProtocol }, {
+        certificateSource: 'cloudflare-rfc9440',
+      });
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'header_missing_or_malformed');
+    });
+
+    it('should report a failure when reading request.headers throws', () => {
+      const request = { get headers() { throw new Error('headers getter blew up'); } };
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'cloudflare-rfc9440',
+      });
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'header_missing_or_malformed');
+    });
+
+    it('should report a failure when the Symbol.iterator accessor throws', () => {
+      const headers = {};
+      Object.defineProperty(headers, Symbol.iterator, {
+        get() { throw new Error('iterator getter blew up'); },
+      });
+      const result = extractClientCertificateFromRequest({ headers }, {
+        certificateSource: 'cloudflare-rfc9440',
+      });
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'header_missing_or_malformed');
+    });
+  });
+
+  describe('without iterable headers', () => {
+    const cases = [
+      ['an undefined request', undefined],
+      ['a request without headers', {}],
+      ['null headers', { headers: null }],
+      ['plain-object headers', { headers: { 'client-cert': 'value' } }],
+    ];
+
+    for (const [label, request] of cases) {
+      it(`should report header_missing_or_malformed for ${label}`, () => {
+        const result = extractClientCertificateFromRequest(request, {
+          certificateSource: 'cloudflare-rfc9440',
+        });
+
+        assert.strictEqual(result.success, false);
+        assert.strictEqual(result.certificate, null);
+        assert.strictEqual(result.reason, 'header_missing_or_malformed');
+      });
+    }
+
+    it('should skip entries that are not [name, value] tuples', () => {
+      const headers = [
+        'client-cert',
+        [42, 'ignored'],
+        ['client-cert', encodeAsRfc9440(testDer)],
+      ];
+
+      const result = extractClientCertificateFromRequest({ headers }, {
+        certificateSource: 'cloudflare-rfc9440',
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
+    });
   });
 
   describe('header-only behavior', () => {


### PR DESCRIPTION
A missing, null, or non-iterable headers field is treated as no headers and fails closed instead of throwing.