### PR TITLE
fix(extractor): report a throwing getPeerCertificate as certificate_not_retrievable

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ Framework-agnostic certificate extraction function exported from `client-certifi
 
 - `'verification_header_mismatch'` - Proxy verify header didn't match expected value
 - `'header_missing_or_malformed'` - Header extraction failed and no fallback configured
-- `'socket_not_authorized'` - Socket not authorized for TLS client cert
-- `'certificate_not_retrievable'` - Socket authorized but getPeerCertificate() returned empty
+- `'socket_not_authorized'` - Socket not authorized for TLS client cert, or unreadable
+- `'certificate_not_retrievable'` - Socket authorized but getPeerCertificate() is missing, returned empty, or threw
 
 **Example - Building a Koa adapter:**
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -229,8 +229,8 @@ Framework-agnostic certificate extraction function exported from `client-certifi
 
 - `'verification_header_mismatch'` — Proxy verify header didn't match expected value
 - `'header_missing_or_malformed'` — Header extraction failed and no fallback configured
-- `'socket_not_authorized'` — Socket not authorized for TLS client cert
-- `'certificate_not_retrievable'` — Socket authorized but `getPeerCertificate()` returned empty
+- `'socket_not_authorized'` — Socket not authorized for TLS client cert, or unreadable
+- `'certificate_not_retrievable'` — Socket authorized but `getPeerCertificate()` is missing, returned empty, or threw
 
 **Example - Building a Koa adapter:**
 

--- a/lib/clientCertificateAuth.cjs
+++ b/lib/clientCertificateAuth.cjs
@@ -153,8 +153,22 @@ function clientCertificateAuth(callback, options = {}) {
     }
 
     return function middleware(req, res, next) {
+        let socket;
+        let authorized = false;
+        let getPeerCertificate;
+        try {
+            socket = req?.socket;
+            authorized = Boolean(socket?.authorized);
+            getPeerCertificate = socket?.getPeerCertificate;
+        } catch {
+            // Whatever threw was not assigned, so an unreadable socket or
+            // authorized flag leaves authorized false, while one that reports
+            // authorized before its getPeerCertificate accessor throws keeps it
+            // and falls through to certificate_not_retrievable.
+        }
+
         // Ensure that the certificate was validated at the protocol level
-        if (!req.socket?.authorized) {
+        if (!authorized) {
             safeCallHook(onRejected, null, req, 'socket_not_authorized');
             const e = new Error('Unauthorized: Client certificate required');
             e.status = 401;
@@ -164,7 +178,7 @@ function clientCertificateAuth(callback, options = {}) {
         // Socket may report authorized: true without exposing TLS methods (mocks,
         // misconfigured non-TLS path that nonetheless sets authorized). Mirrors the
         // guard in the ESM extractor (lib/extractor.js).
-        if (typeof req.socket.getPeerCertificate !== 'function') {
+        if (typeof getPeerCertificate !== 'function') {
             safeCallHook(onRejected, null, req, 'certificate_not_retrievable');
             const e = new Error(
                 'Client certificate was authenticated but certificate information could not be retrieved.'
@@ -174,7 +188,12 @@ function clientCertificateAuth(callback, options = {}) {
         }
 
         // Obtain certificate details
-        const cert = req.socket.getPeerCertificate(includeChain);
+        let cert;
+        try {
+            cert = getPeerCertificate.call(socket, includeChain);
+        } catch {
+            cert = null;
+        }
         if (!cert || Object.keys(cert).length === 0) {
             safeCallHook(onRejected, null, req, 'certificate_not_retrievable');
             const e = new Error(

--- a/lib/extractor.d.ts
+++ b/lib/extractor.d.ts
@@ -7,8 +7,8 @@
  * Rejection reasons:
  * - 'verification_header_mismatch' - Proxy verify header didn't match expected value
  * - 'header_missing_or_malformed' - Header extraction failed and no fallback configured
- * - 'socket_not_authorized' - Socket not authorized for TLS client cert
- * - 'certificate_not_retrievable' - Socket authorized but getPeerCertificate() returned empty
+ * - 'socket_not_authorized' - Socket not authorized for TLS client cert, or unreadable
+ * - 'certificate_not_retrievable' - Socket authorized but getPeerCertificate() is missing, returned empty, or threw
  */
 /**
  * @typedef {Object} ExtractorOptions
@@ -92,8 +92,8 @@ export type ExtractionResult = {
      * Rejection reasons:
      * - 'verification_header_mismatch' - Proxy verify header didn't match expected value
      * - 'header_missing_or_malformed' - Header extraction failed and no fallback configured
-     * - 'socket_not_authorized' - Socket not authorized for TLS client cert
-     * - 'certificate_not_retrievable' - Socket authorized but getPeerCertificate() returned empty
+     * - 'socket_not_authorized' - Socket not authorized for TLS client cert, or unreadable
+     * - 'certificate_not_retrievable' - Socket authorized but getPeerCertificate() is missing, returned empty, or threw
      */
     reason: string | null;
 };

--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -129,8 +129,8 @@ export function validateExtractorOptions(options = {}) {
  * Rejection reasons:
  * - 'verification_header_mismatch' - Proxy verify header didn't match expected value
  * - 'header_missing_or_malformed' - Header extraction failed and no fallback configured
- * - 'socket_not_authorized' - Socket not authorized for TLS client cert
- * - 'certificate_not_retrievable' - Socket authorized but getPeerCertificate() returned empty
+ * - 'socket_not_authorized' - Socket not authorized for TLS client cert, or unreadable
+ * - 'certificate_not_retrievable' - Socket authorized but getPeerCertificate() is missing, returned empty, or threw
  */
 
 /**
@@ -319,8 +319,24 @@ export function extractClientCertificate(req, options = {}) {
 
   // Fallback to socket-based extraction (original behavior)
   if (!cert) {
+    /** @type {any} */
+    let socket;
+    let authorized = false;
+    /** @type {any} */
+    let getPeerCertificate;
+    try {
+      socket = req?.socket;
+      authorized = Boolean(socket?.authorized);
+      getPeerCertificate = socket?.getPeerCertificate;
+    } catch {
+      // Whatever threw was not assigned, so an unreadable socket or authorized
+      // flag leaves authorized false, while one that reports authorized before
+      // its getPeerCertificate accessor throws keeps it and falls through to
+      // certificate_not_retrievable.
+    }
+
     // Ensure that the certificate was validated at the protocol level
-    if (!req?.socket?.authorized) {
+    if (!authorized) {
       return {
         success: false,
         certificate: null,
@@ -329,8 +345,7 @@ export function extractClientCertificate(req, options = {}) {
     }
 
     // Obtain certificate details from socket
-    // TypeScript: cast to TLSSocket since we've validated this is a TLS connection
-    if (typeof req.socket.getPeerCertificate !== 'function') {
+    if (typeof getPeerCertificate !== 'function') {
       return {
         success: false,
         certificate: null,
@@ -338,7 +353,11 @@ export function extractClientCertificate(req, options = {}) {
       };
     }
 
-    cert = /** @type {import('tls').TLSSocket} */ (req.socket).getPeerCertificate(includeChain);
+    try {
+      cert = getPeerCertificate.call(socket, includeChain);
+    } catch {
+      cert = null;
+    }
     if (!cert || Object.keys(cert).length === 0) {
       // Handle the case where a certificate was validated but we can't inspect it
       return {

--- a/test/test-unit-clientCertificateAuth.cjs
+++ b/test/test-unit-clientCertificateAuth.cjs
@@ -566,6 +566,62 @@ describe('clientCertificateAuth (CommonJS)', () => {
                     done();
                 });
             });
+
+            it('should pass 401 error to next() when the socket accessor throws', done => {
+                const reqThrowingSocket = {
+                    secure: true,
+                    get socket() { throw new Error('socket destroyed'); }
+                };
+                const middleware = clientCertificateAuth(() => true);
+                middleware(reqThrowingSocket, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.status, 401);
+                    done();
+                });
+            });
+
+            it('should pass 401 error to next() when the authorized accessor throws', done => {
+                const reqThrowingAuthorized = {
+                    ...mockGoodReq,
+                    socket: { get authorized() { throw new Error('socket destroyed'); } }
+                };
+                const middleware = clientCertificateAuth(() => true);
+                middleware(reqThrowingAuthorized, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.status, 401);
+                    done();
+                });
+            });
+
+            it('should pass 500 error to next() when the getPeerCertificate accessor throws', done => {
+                const reqThrowingAccessor = {
+                    ...mockGoodReq,
+                    socket: {
+                        authorized: true,
+                        get getPeerCertificate() { throw new Error('socket destroyed'); }
+                    }
+                };
+                const middleware = clientCertificateAuth(() => true);
+                middleware(reqThrowingAccessor, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.status, 500);
+                    done();
+                });
+            });
+
+            it('should pass 500 error to next() when getPeerCertificate throws', done => {
+                const reqThrowingCert = {
+                    ...mockGoodReq,
+                    socket: { authorized: true, getPeerCertificate: () => { throw new Error('handle destroyed'); } }
+                };
+                const middleware = clientCertificateAuth(() => true);
+                middleware(reqThrowingCert, mockRes, (err) => {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.status, 500);
+                    assert.ok(err.message.includes('could not be retrieved'));
+                    done();
+                });
+            });
         });
 
         describe('client-facing error sanitization', () => {

--- a/test/test-unit-clientCertificateAuth.js
+++ b/test/test-unit-clientCertificateAuth.js
@@ -546,6 +546,20 @@ describe('clientCertificateAuth', () => {
           done();
         });
       });
+
+      it('should pass 500 error to next() when getPeerCertificate throws', done => {
+        const reqThrowingCert = {
+          ...mockGoodReq,
+          socket: { authorized: true, getPeerCertificate: () => { throw new Error('handle destroyed'); } }
+        };
+        const middleware = clientCertificateAuth(() => true);
+        middleware(reqThrowingCert, mockRes, (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.status, 500);
+          assert.ok(err.message.includes('could not be retrieved'));
+          done();
+        });
+      });
     });
 
 

--- a/test/test-unit-extractor.js
+++ b/test/test-unit-extractor.js
@@ -687,6 +687,59 @@ describe('extractClientCertificate', () => {
 
       assert.strictEqual(result.success, true);
     });
+
+    it('should report socket_not_authorized when the socket accessor throws', () => {
+      const req = { headers: {}, get socket() { throw new Error('socket destroyed'); } };
+
+      const result = extractClientCertificate(req);
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.certificate, null);
+      assert.strictEqual(result.reason, 'socket_not_authorized');
+    });
+
+    it('should report socket_not_authorized when the authorized accessor throws', () => {
+      const req = {
+        headers: {},
+        socket: { get authorized() { throw new Error('socket destroyed'); } },
+      };
+
+      const result = extractClientCertificate(req);
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'socket_not_authorized');
+    });
+
+    it('should report certificate_not_retrievable when the getPeerCertificate accessor throws', () => {
+      const req = {
+        headers: {},
+        socket: {
+          authorized: true,
+          get getPeerCertificate() { throw new Error('socket destroyed'); },
+        },
+      };
+
+      const result = extractClientCertificate(req);
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'certificate_not_retrievable');
+    });
+
+    it('should report certificate_not_retrievable when getPeerCertificate throws', () => {
+      const req = {
+        headers: {},
+        socket: {
+          authorized: true,
+          getPeerCertificate: () => { throw new Error('handle destroyed'); },
+        },
+      };
+
+      const result = extractClientCertificate(req);
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.certificate, null);
+      assert.strictEqual(result.reason, 'certificate_not_retrievable');
+    });
   });
 
   describe('header extraction', () => {


### PR DESCRIPTION
A getPeerCertificate() that throws is reported as certificate_not_retrievable, like an empty result.