### PR TITLE
fix(cjs): ignore unsupported options that are explicitly undefined

### DIFF
--- a/lib/clientCertificateAuth.cjs
+++ b/lib/clientCertificateAuth.cjs
@@ -78,7 +78,7 @@ function clientCertificateAuth(callback, options = {}) {
     }
 
     // Validate that no unsupported options are passed
-    const used = UNSUPPORTED_OPTIONS.filter(k => k in options);
+    const used = UNSUPPORTED_OPTIONS.filter(k => options[k] !== undefined);
     if (used.length) {
         throw new Error(
             `CJS sync wrapper does not support: ${used.join(', ')}. ` +

--- a/test/test-unit-clientCertificateAuth.cjs
+++ b/test/test-unit-clientCertificateAuth.cjs
@@ -964,6 +964,10 @@ describe('clientCertificateAuth (CommonJS)', () => {
             );
         });
 
+        it('should not throw when an unsupported option is explicitly undefined', () => {
+            assert.doesNotThrow(() => clientCertificateAuth(() => true, { certificateSource: undefined }));
+        });
+
         it('should include load() guidance in error message', () => {
             assert.throws(
                 () => clientCertificateAuth(() => true, { certificateHeader: 'X-SSL-Cert' }),


### PR DESCRIPTION
The sync wrapper no longer rejects unsupported options whose value is explicitly undefined.