### PR TITLE
fix(helpers): keep URI paths case-sensitive and decode quoted SAN values

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,8 @@ app.use(clientCertificateAuth(allowSerial(['01:23:45:67:89:AB:CD:EF'])));
 app.use(clientCertificateAuth(allowSAN(['DNS:api.example.com', 'email:service@example.com'])));
 ```
 
+`allowSAN` values without a type prefix match under any SAN type. Matching is case-insensitive except within URIs, where only the scheme and host are folded; userinfo, path, query, and fragment must match exactly.
+
 ### Field Matching
 
 Match certificates by issuer or subject fields (all specified fields must match):

--- a/docs/guide/helpers.md
+++ b/docs/guide/helpers.md
@@ -41,6 +41,8 @@ app.use(clientCertificateAuth(allowSerial(['01:23:45:67:89:AB:CD:EF'])));
 app.use(clientCertificateAuth(allowSAN(['DNS:api.example.com', 'email:service@example.com'])));
 ```
 
+`allowSAN` values without a type prefix match under any SAN type. Matching is case-insensitive except within URIs, where only the scheme and host are folded; userinfo, path, query, and fragment must match exactly.
+
 ## Field Matching
 
 Match certificates by issuer or subject fields. All specified fields must match for the callback to return `true`:

--- a/lib/helpers.d.ts
+++ b/lib/helpers.d.ts
@@ -77,6 +77,9 @@ export declare function allowSerial(serials: string[]): ValidationCallback;
 /**
  * Create a validation callback that allows certificates with matching Subject Alternative Names.
  * Checks the subjectaltname field (format: "DNS:example.com, email:user@example.com").
+ * Bare values (no type prefix) match under any SAN type. Comparison is case-insensitive
+ * except for URI userinfo, path, query, and fragment; JSON-quoted values in Node's SAN rendering
+ * are decoded first.
  * @param values - Allowed SAN values (e.g., "DNS:example.com", "example.com", "user@example.com")
  */
 export declare function allowSAN(values: string[]): ValidationCallback;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -163,9 +163,82 @@ export function allowSerial(serials) {
     };
 }
 
+const SAN_TYPES = new Set(['dns', 'email', 'uri', 'ip address', 'dirname', 'registered id', 'othername']);
+
+/**
+ * Split "type:value" at a recognized SAN type prefix. Unknown prefixes stay
+ * in the value so bare items like "https://x" or "::1" keep their colons.
+ * @param {string} text
+ * @returns {{ type: string | null, value: string }}
+ */
+function splitSanType(text) {
+    const colonIdx = text.indexOf(':');
+    if (colonIdx !== -1) {
+        let type = text.slice(0, colonIdx).toLowerCase();
+        if (type === 'ip') {type = 'ip address';}
+        if (SAN_TYPES.has(type)) {
+            return { type, value: text.slice(colonIdx + 1) };
+        }
+    }
+    return { type: null, value: text };
+}
+
+/**
+ * Node renders SAN values containing commas, quotes, backslashes, or control
+ * characters as JSON strings.
+ * @param {string} value
+ * @returns {string}
+ */
+function decodeSanValue(value) {
+    if (!value.startsWith('"')) {
+        return value;
+    }
+    try {
+        return JSON.parse(value);
+    } catch {
+        return value;
+    }
+}
+
+/**
+ * Case-fold a URI for comparison: the scheme and host are case-insensitive,
+ * while userinfo, path, query, and fragment are not (RFC 3986 section 6.2.2.1).
+ * @param {string} value
+ * @returns {string}
+ */
+function foldUri(value) {
+    const scheme = /^[a-z][a-z0-9+.-]*:/i.exec(value);
+    if (!scheme) {return value;}
+    let folded = scheme[0].toLowerCase();
+    let rest = value.slice(scheme[0].length);
+    if (rest.startsWith('//')) {
+        const end = rest.slice(2).search(/[/?#]/);
+        const authority = end === -1 ? rest.slice(2) : rest.slice(2, 2 + end);
+        rest = end === -1 ? '' : rest.slice(2 + end);
+        const at = authority.lastIndexOf('@');
+        folded += '//' + authority.slice(0, at + 1) + authority.slice(at + 1).toLowerCase();
+    }
+    return folded + rest;
+}
+
+/**
+ * Case-fold a SAN value for comparison. URIs fold their scheme and host;
+ * every other type folds the whole value.
+ * @param {string | null} type
+ * @param {string} value
+ * @returns {string}
+ */
+function foldSanValue(type, value) {
+    return type === 'uri' ? foldUri(value) : value.toLowerCase();
+}
+
 /**
  * Create a validation callback that allows certificates with matching Subject Alternative Names.
- * Checks the subjectaltname field (format: "DNS:example.com, email:user@example.com").
+ * Values may carry a type prefix ("DNS:api.example.com") or be bare, in which case they match
+ * that value under any SAN type. Type prefixes, DNS names, email addresses, and IP addresses
+ * compare case-insensitively; URIs fold only the scheme and host, so userinfo, path, query,
+ * and fragment stay case-sensitive. Values Node renders JSON-quoted (containing commas, quotes,
+ * or control characters) are decoded before comparison.
  *
  * @param {string[]} values - Allowed SAN values (e.g., "DNS:example.com", "example.com", "user@example.com")
  * @returns {ValidationCallback}
@@ -174,26 +247,23 @@ export function allowSerial(serials) {
  * app.use(clientCertificateAuth(allowSAN(['DNS:api.example.com', 'email:admin@example.com'])));
  */
 export function allowSAN(values) {
-    // Normalize: if no prefix, match as-is; otherwise match the full "type:value" format
-    const allowed = new Set(values.map((v) => v.toLowerCase()));
+    const allowed = values.map((v) => splitSanType(v));
 
     return (cert) => {
         if (!cert.subjectaltname) {return false;}
 
-        // Parse SAN string: "DNS:example.com, email:user@example.com, URI:https://..."
-        const entries = cert.subjectaltname.split(/,\s*/).map((e) => e.toLowerCase());
+        // Node joins entries with ", " and JSON-quotes any value containing a comma.
+        const entries = cert.subjectaltname.split(/,\s*/).map((entry) => {
+            const { type, value } = splitSanType(entry);
+            return { type, value: decodeSanValue(value) };
+        });
 
-        // Check if any SAN entry matches (either full "type:value" or just the value part)
-        return entries.some((entry) => {
-            if (allowed.has(entry)) {return true;}
-            // Also check just the value part (after the colon)
-            const colonIdx = entry.indexOf(':');
-            // Stryker disable next-line ConditionalExpression: when true, slice(0) returns full entry which was already checked on line 159
-            if (colonIdx !== -1) {
-                const value = entry.slice(colonIdx + 1);
-                if (allowed.has(value)) {return true;}
-            }
-            return false;
+        return entries.some(({ type, value }) => {
+            const folded = foldSanValue(type, value);
+            return allowed.some((item) =>
+                (item.type === null || item.type === type)
+                    && foldSanValue(type, item.value) === folded
+            );
         });
     };
 }
@@ -221,12 +291,9 @@ export function allowEmail(emails) {
 
         // Check SAN for email entries
         if (cert.subjectaltname) {
-            const entries = cert.subjectaltname.split(/,\s*/);
-            for (const entry of entries) {
-                if (entry.toLowerCase().startsWith('email:')) {
-                    const email = entry.slice(6).toLowerCase();
-                    if (allowed.has(email)) {return true;}
-                }
+            for (const entry of cert.subjectaltname.split(/,\s*/)) {
+                const { type, value } = splitSanType(entry);
+                if (type === 'email' && allowed.has(decodeSanValue(value).toLowerCase())) {return true;}
             }
         }
 

--- a/test/test-unit-helpers.js
+++ b/test/test-unit-helpers.js
@@ -548,12 +548,69 @@ describe('helpers', () => {
             assert.equal(check(certMalformedSAN), false);
         });
 
-        it('should match value-only for SAN with short type prefix', () => {
-            // Kills UnaryOperator mutation: colonIdx !== -1 → colonIdx !== +1
-            // IP: has colon at index 2, but a synthetic 1-char prefix has colon at index 1
+        it('should compare an unrecognized type prefix as part of the value', () => {
             const cert = { subjectaltname: 'X:short-prefix-value' };
-            const check = allowSAN(['short-prefix-value']);
-            assert.equal(check(cert), true);
+            assert.equal(allowSAN(['x:SHORT-prefix-value'])(cert), true);
+            assert.equal(allowSAN(['short-prefix-value'])(cert), false);
+        });
+
+        it('should not match a typed value against a different SAN type', () => {
+            assert.equal(allowSAN(['DNS:alt@example.com'])(mockCert), false);
+            assert.equal(allowSAN(['email:test.example.com'])(mockCert), false);
+        });
+
+        it('should accept IP: as an alias for IP Address:', () => {
+            const cert = { subjectaltname: 'IP Address:10.0.0.1' };
+            assert.equal(allowSAN(['IP:10.0.0.1'])(cert), true);
+            assert.equal(allowSAN(['ip:10.0.0.2'])(cert), false);
+        });
+
+        it('should split the DirName and Registered ID prefixes OpenSSL renders', () => {
+            const dirName = { subjectaltname: 'DirName:/CN=Directory Name' };
+            assert.equal(allowSAN(['DirName:/CN=Directory Name'])(dirName), true);
+            assert.equal(allowSAN(['dirname:/cn=directory name'])(dirName), true);
+            assert.equal(allowSAN(['DNS:/CN=Directory Name'])(dirName), false);
+
+            const registeredId = { subjectaltname: 'Registered ID:1.3.6.1.4.1.311.20.2.3' };
+            assert.equal(allowSAN(['Registered ID:1.3.6.1.4.1.311.20.2.3'])(registeredId), true);
+            assert.equal(allowSAN(['DNS:1.3.6.1.4.1.311.20.2.3'])(registeredId), false);
+        });
+
+        it('should keep URI paths case-sensitive while folding scheme and host', () => {
+            const cert = { subjectaltname: 'URI:https://Example.com/Path/A' };
+            assert.equal(allowSAN(['URI:https://example.com/path/a'])(cert), false);
+            assert.equal(allowSAN(['URI:HTTPS://EXAMPLE.COM/Path/A'])(cert), true);
+            assert.equal(allowSAN(['https://example.com/Path/A'])(cert), true);
+            assert.equal(allowSAN(['uri:https://example.com/Path/A?Q=1'])(cert), false);
+        });
+
+        it('should fold only the scheme of URIs without an authority', () => {
+            const cert = { subjectaltname: 'URI:urn:example:Abc' };
+            assert.equal(allowSAN(['URI:URN:example:Abc'])(cert), true);
+            assert.equal(allowSAN(['URI:urn:example:abc'])(cert), false);
+            assert.equal(allowSAN(['URI:not a uri'])({ subjectaltname: 'URI:Not A URI' }), false);
+        });
+
+        it('should keep URI userinfo case-sensitive', () => {
+            const cert = { subjectaltname: 'URI:https://User@Example.com:8443/Path' };
+            assert.equal(allowSAN(['URI:HTTPS://User@EXAMPLE.COM:8443/Path'])(cert), true);
+            assert.equal(allowSAN(['URI:https://user@example.com:8443/Path'])(cert), false);
+        });
+
+        it('should decode JSON-quoted SAN values', () => {
+            const cert = {
+                subjectaltname: 'URI:"https://example.com/x\\u002cy", othername:"UPN:first\\u002clast@example.com", DNS:"a\\"b.example.com"',
+            };
+            assert.equal(allowSAN(['URI:https://example.com/x,y'])(cert), true);
+            assert.equal(allowSAN(['othername:UPN:first,last@example.com'])(cert), true);
+            assert.equal(allowSAN(['a"b.example.com'])(cert), true);
+            assert.equal(allowSAN(['URI:https://example.com/x'])(cert), false);
+        });
+
+        it('should fall back to the raw text when a quoted value is not valid JSON', () => {
+            const cert = { subjectaltname: 'DNS:"broken\\x"' };
+            assert.equal(allowSAN(['DNS:"BROKEN\\x"'])(cert), true);
+            assert.equal(allowSAN(['DNS:broken'])(cert), false);
         });
     });
 
@@ -600,9 +657,14 @@ describe('helpers', () => {
         });
 
         it('should not match non-email SAN type even if value at offset 6 matches', () => {
-            // With startsWith mutation (→ true), "URI:x:me@test.com".slice(6) would be "me@test.com" → false positive
             const cert = { subjectaltname: 'URI:x:me@test.com' };
             assert.equal(allowEmail(['me@test.com'])(cert), false);
+        });
+
+        it('should decode a JSON-quoted SAN email', () => {
+            const cert = { subjectaltname: 'email:"First\\u002cLast@example.com"' };
+            assert.equal(allowEmail(['first,last@example.com'])(cert), true);
+            assert.equal(allowEmail(['first@example.com'])(cert), false);
         });
 
         it('should match subject.emailAddress when SAN has no email entries', () => {


### PR DESCRIPTION
URI SAN matching folds only scheme and host, and JSON-quoted SAN values are decoded before comparison.