### PR TITLE
fix(parsers): match XFCC keys case-insensitively

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -228,8 +228,9 @@ export function parseUrlPemAws(headerValue) {
  * Parse Envoy XFCC (X-Forwarded-Client-Cert) structured header format.
  * Format: Key=Value;Key=Value;... where Cert (single URL-encoded PEM) or
  * Chain (URL-encoded multi-block PEM with the full chain incl. leaf) carry
- * the certificate. When both are present we prefer Chain because it carries
- * more information, and link the chain via issuerCertificate.
+ * the certificate. Keys are case-insensitive. When both are present we
+ * prefer Chain because it carries more information, and link the chain via
+ * issuerCertificate.
  *
  * @see https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert
  * @param {string} headerValue - XFCC formatted header value
@@ -274,11 +275,12 @@ export function parseXfcc(headerValue) {
             }
 
             // Stryker disable next-line MethodExpression: defensive normalization, no real proxy sends whitespace
-            const key = pair.substring(0, eqIndex).trim();
+            const rawKey = pair.substring(0, eqIndex).trim();
+            const key = rawKey.toLowerCase();
             // Stryker disable next-line MethodExpression: defensive normalization, no real proxy sends whitespace
             let value = pair.substring(eqIndex + 1).trim();
 
-            if (key === 'Cert' || key === 'Chain') {
+            if (key === 'cert' || key === 'chain') {
                 // Stryker disable next-line LogicalOperator,MethodExpression,StringLiteral,BlockStatement: quote-stripping mutations are equivalent given the secondary unbalanced-quote reject below and lenient PEM marker scan downstream — broken quotes either trigger reject or produce a stripped value that fails to parse, both yielding null
                 if (value.startsWith('"') && value.endsWith('"')) {
                     // Stryker disable next-line MethodExpression: skipping the slice leaves quotes around the value; PEM marker scan still finds BEGIN/END inside them and parses the cert content correctly — equivalent for tests
@@ -288,7 +290,7 @@ export function parseXfcc(headerValue) {
                     // than parse the cert content out of the broken wrapping.
                     return null;
                 }
-                if (key === 'Chain') {
+                if (key === 'chain') {
                     chainValue = value;
                 } else {
                     certValue = value;

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -321,6 +321,17 @@ describe('parsers module', () => {
             assert.equal(parseXfcc(xfcc), null);
         });
 
+        it('should match the Cert and Chain keys case-insensitively', () => {
+            const encodedPem = encodeURIComponent(testPem);
+            const viaCert = parseXfcc(`Hash=abc;cert="${encodedPem}"`);
+            const viaChain = parseXfcc(`Hash=abc;CHAIN="${encodedPem}"`);
+
+            assert.ok(viaCert);
+            assert.equal(viaCert.subject.CN, 'Test Parser Client');
+            assert.ok(viaChain);
+            assert.equal(viaChain.subject.CN, 'Test Parser Client');
+        });
+
         it('should return null for empty input', () => {
             assert.equal(parseXfcc(''), null);
         });


### PR DESCRIPTION
parseXfcc recognizes the Cert and Chain keys in any capitalization.