### PR TITLE
fix(helpers): treat an unprefixed 64-hex fingerprint as SHA-256

### DIFF
--- a/lib/helpers.d.ts
+++ b/lib/helpers.d.ts
@@ -36,7 +36,8 @@ export declare function allowCN(names: string[]): ValidationCallback;
  * Create a validation callback that allows certificates with matching fingerprints.
  * Supports SHA-1 fingerprints (compared against cert.fingerprint) and SHA-256
  * fingerprints with "SHA256:" prefix (compared against cert.fingerprint256).
- * Fingerprints without a prefix are treated as SHA-1.
+ * Fingerprints without a prefix are treated as SHA-1 unless they carry 64 hex
+ * digits, which is SHA-256.
  * @param fingerprints - Allowed fingerprints
  */
 export declare function allowFingerprints(fingerprints: string[]): ValidationCallback;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -38,8 +38,9 @@ export function allowCN(names) {
  * Create a validation callback that allows certificates with matching fingerprints.
  * Supports SHA-1 fingerprints (compared against cert.fingerprint) and SHA-256
  * fingerprints with "SHA256:" prefix (compared against cert.fingerprint256).
- * Fingerprints without a prefix are treated as SHA-1. Hex inputs are
- * normalized: case and colon delimiters are ignored on both sides.
+ * Fingerprints without a prefix are treated as SHA-1 unless they carry 64
+ * hex digits, which is SHA-256. Hex inputs are normalized: case and colon
+ * delimiters are ignored on both sides.
  *
  * @param {string[]} fingerprints - Allowed fingerprints
  * @returns {ValidationCallback}
@@ -61,7 +62,8 @@ export function allowFingerprints(fingerprints) {
         if (upper.startsWith('SHA256:')) {
             sha256Allowed.add(normalize(upper.slice(7)));
         } else {
-            sha1Allowed.add(normalize(upper));
+            const digest = normalize(upper);
+            (digest.length === 64 ? sha256Allowed : sha1Allowed).add(digest);
         }
     }
 

--- a/test/test-unit-helpers.js
+++ b/test/test-unit-helpers.js
@@ -143,6 +143,13 @@ describe('helpers', () => {
             assert.equal(check(mockCert), true);
         });
 
+        it('should treat an unprefixed 64-hex-digit fingerprint as SHA-256', () => {
+            const bare = 'AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99';
+            assert.equal(allowFingerprints([bare])(mockCert), true);
+            assert.equal(allowFingerprints([bare.replace(/:/g, '').toLowerCase()])(mockCert), true);
+            assert.equal(allowFingerprints([bare])({ fingerprint: mockCert.fingerprint }), false);
+        });
+
         it('should match SHA-1 fingerprint with arbitrary colon placement', () => {
             const check = allowFingerprints(['ABCD:EF0123456789AB:CDEF0123456789ABCDEF01']);
             assert.equal(check(mockCert), true);


### PR DESCRIPTION
An unprefixed 64-hex-digit fingerprint is compared against fingerprint256.