### PR TITLE
fix(middleware): default the rejection message for unmapped reasons

### DIFF
--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -162,7 +162,8 @@ export default function clientCertificateAuth(callback, options = {}) {
       safeCallHook(onRejected, null, req, result.reason);
 
       // Map rejection reasons to user-friendly error messages
-      let errorMessage;
+      // Stryker disable next-line StringLiteral: fallback for reasons without a mapped message, unreachable with the current extractor
+      let errorMessage = 'Unauthorized';
       let statusCode = 401;
 
       switch (result.reason) {


### PR DESCRIPTION
Rejection errors for unmapped reasons get the message 'Unauthorized' instead of an empty string.