### PR TITLE
feat(helpers): add allowCA for signature verification against configured CAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,7 +657,11 @@ Pre-built validation callbacks for common authorization patterns, available as a
 
 ```javascript
 import clientCertificateAuth from 'client-certificate-auth';
-import { allowCN, allowFingerprints, allowIssuer, allOf, anyOf } from 'client-certificate-auth/helpers';
+import {
+  allowCA, allowCN, allowEmail, allowFingerprints, allowIssuer, allowOrganization,
+  allowOU, allowSAN, allowSerial, allowSubject, allOf, anyOf
+} from 'client-certificate-auth/helpers';
+import { readFileSync } from 'node:fs';
 ```
 
 > **Note:** In CommonJS, the `/helpers`, `/parsers`, and `/extractor` subpath exports provide a `load()` function for async access. See the [CommonJS](#commonjs) section for details.
@@ -688,6 +692,13 @@ app.use(clientCertificateAuth(allowSerial(['01:23:45:67:89:AB:CD:EF'])));
 
 // Allowlist by Subject Alternative Name
 app.use(clientCertificateAuth(allowSAN(['DNS:api.example.com', 'email:service@example.com'])));
+
+// Verify the certificate chains to a CA you control (needed behind passthrough proxies)
+// The header carries only the public certificate: the app must be reachable only through the proxy.
+app.use(clientCertificateAuth(allowCA(readFileSync('ca.pem')), {
+  certificateSource: 'aws-alb',
+  includeChain: true
+}));
 ```
 
 `allowSAN` values without a type prefix match under any SAN type. Matching is case-insensitive except within URIs, where only the scheme and host are folded; userinfo, path, query, and fragment must match exactly.
@@ -733,6 +744,7 @@ app.use(clientCertificateAuth(anyOf(
 | `allowSerial(serials)` | Match by serial number |
 | `allowSAN(values)` | Match by Subject Alternative Name |
 | `allowEmail(emails)` | Match by email (SAN or subject) |
+| `allowCA(cas, options?)` | Verify the chain against your own CA certificates |
 | `allOf(...callbacks)` | AND combinator |
 | `anyOf(...callbacks)` | OR combinator |
 

--- a/docs/guide/helpers.md
+++ b/docs/guide/helpers.md
@@ -4,7 +4,11 @@ Pre-built validation callbacks cover common authorization patterns so you don't 
 
 ```javascript
 import clientCertificateAuth from 'client-certificate-auth';
-import { allowCN, allowFingerprints, allowIssuer, allOf, anyOf } from 'client-certificate-auth/helpers';
+import {
+  allowCA, allowCN, allowEmail, allowFingerprints, allowIssuer, allowOrganization,
+  allowOU, allowSAN, allowSerial, allowSubject, allOf, anyOf
+} from 'client-certificate-auth/helpers';
+import { readFileSync } from 'node:fs';
 ```
 
 ::: info CommonJS note
@@ -39,6 +43,13 @@ app.use(clientCertificateAuth(allowSerial(['01:23:45:67:89:AB:CD:EF'])));
 
 // Allowlist by Subject Alternative Name
 app.use(clientCertificateAuth(allowSAN(['DNS:api.example.com', 'email:service@example.com'])));
+
+// Verify the certificate chains to a CA you control (needed behind passthrough proxies)
+// The header carries only the public certificate: the app must be reachable only through the proxy.
+app.use(clientCertificateAuth(allowCA(readFileSync('ca.pem')), {
+  certificateSource: 'aws-alb',
+  includeChain: true
+}));
 ```
 
 `allowSAN` values without a type prefix match under any SAN type. Matching is case-insensitive except within URIs, where only the scheme and host are folded; userinfo, path, query, and fragment must match exactly.
@@ -95,6 +106,7 @@ app.use(clientCertificateAuth(allOf(
 | `allowSerial(serials)` | Match by serial number |
 | `allowSAN(values)` | Match by Subject Alternative Name |
 | `allowEmail(emails)` | Match by email (SAN or subject) |
+| `allowCA(cas, options?)` | Verify the chain against your own CA certificates |
 | `allOf(...callbacks)` | AND combinator - all must pass |
 | `anyOf(...callbacks)` | OR combinator - at least one must pass |
 

--- a/lib/helpers.d.ts
+++ b/lib/helpers.d.ts
@@ -93,6 +93,30 @@ export declare function allowSAN(values: string[]): ValidationCallback;
 export declare function allowEmail(emails: string[]): ValidationCallback;
 
 /**
+ * Create a validation callback that accepts certificates issued by one of the given
+ * CA certificates, directly or through the `issuerCertificate` chain attached with
+ * `includeChain: true`. Performs the subset of PKIX path validation that applies to a
+ * forwarded client certificate: issuer name and signature at every link, keyUsage
+ * keyCertSign where an issuer carries it, basicConstraints cA on every CA including the
+ * anchor, pathLenConstraint counting non-self-issued intermediates, clientAuth in the
+ * Extended Key Usage of every certificate on the path that carries one, digitalSignature
+ * or keyAgreement in the leaf's keyUsage when present, validity windows on every
+ * certificate, and rejection of any certificate carrying name constraints at any criticality
+ * or any other critical extension it does not process, so a name-constrained intermediate
+ * anywhere in the chain fails the check. Does
+ * not check revocation. Anchors must be CA certificates that permit clientAuth. Throws at
+ * construction if a CA certificate cannot be parsed, is not a CA, does not permit
+ * clientAuth, carries name constraints or an unsupported critical extension, or sits in a
+ * PEM bundle whose blocks cannot all be read, and if `maxDepth` is not a positive integer.
+ * @param caCertificates - PEM or DER encoded CA certificates; a PEM bundle contributes every certificate it holds
+ * @param options - `maxDepth` bounds the number of certificates walked, leaf included (default 10)
+ */
+export declare function allowCA(
+    caCertificates: string | Buffer | Array<string | Buffer>,
+    options?: { maxDepth?: number }
+): ValidationCallback;
+
+/**
  * Combine multiple validation callbacks with AND logic.
  * All callbacks must return true for the certificate to be authorized.
  * @param callbacks - Validation callbacks to combine

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,6 +4,9 @@
  * @license MIT
  */
 
+import { X509Certificate } from 'node:crypto';
+import { splitPemBlocks } from './parsers.js';
+
 /**
  * @typedef {import('tls').PeerCertificate} PeerCertificate
  * @typedef {(cert: PeerCertificate, req?: import('http').IncomingMessage) => boolean | Promise<boolean>} ValidationCallback
@@ -299,6 +302,365 @@ export function allowEmail(emails) {
             }
         }
 
+        return false;
+    };
+}
+
+/**
+ * Parse a certificate object's DER bytes; null when there are none.
+ * @param {import('./parsers.js').ChainedPeerCertificate} cert
+ * @returns {X509Certificate | null}
+ */
+function toX509(cert) {
+    try {
+        return new X509Certificate(cert.raw);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * @param {X509Certificate} x509
+ * @param {number} now
+ * @returns {boolean}
+ */
+function withinValidity(x509, now) {
+    return Date.parse(x509.validFrom) <= now && now <= Date.parse(x509.validTo);
+}
+
+/**
+ * @param {X509Certificate} subject
+ * @param {X509Certificate} issuer
+ * @returns {boolean}
+ */
+function issuedBy(subject, issuer) {
+    return subject.checkIssued(issuer) && subject.verify(issuer.publicKey);
+}
+
+const CLIENT_AUTH_OID = '1.3.6.1.5.5.7.3.2';
+const BASIC_CONSTRAINTS_OID = '2.5.29.19';
+const KEY_USAGE_OID = '2.5.29.15';
+const KU_DIGITAL_SIGNATURE = 0x80;
+const KU_KEY_AGREEMENT = 0x08;
+
+/**
+ * Extensions the path check processes. keyUsage, basicConstraints, and
+ * extKeyUsage are read directly; subjectKeyIdentifier and
+ * authorityKeyIdentifier are consumed by checkIssued(); subjectAltName is
+ * carried through to the application, and is critical on certificates with
+ * an empty subject (RFC 5280 s4.2.1.6). A certificate carrying any other
+ * critical extension (certificate policies among them) is rejected, as
+ * RFC 5280 requires of a validator that does not process it.
+ */
+const PROCESSED_EXTENSIONS = new Set([
+    '2.5.29.14', // subjectKeyIdentifier
+    '2.5.29.15', // keyUsage
+    '2.5.29.17', // subjectAltName
+    '2.5.29.19', // basicConstraints
+    '2.5.29.35', // authorityKeyIdentifier
+    '2.5.29.37', // extKeyUsage
+]);
+
+/**
+ * Constraints a conforming validator enforces at any criticality. They are
+ * not processed here, so a certificate carrying one is rejected outright.
+ */
+const UNPROCESSED_CONSTRAINTS = new Set([
+    '2.5.29.30', // nameConstraints
+]);
+
+/**
+ * Read one DER element: its tag and the bounds of its content.
+ * @param {Buffer} der
+ * @param {number} offset
+ * @returns {{ tag: number, start: number, end: number }}
+ */
+function readElement(der, offset) {
+    const tag = der[offset];
+    let length = der[offset + 1];
+    let start = offset + 2;
+    if (length & 0x80) {
+        const size = length & 0x7f;
+        length = 0;
+        for (let i = 0; i < size; i++) {
+            length = length * 256 + der[start + i];
+        }
+        start += size;
+    }
+    return { tag, start, end: start + length };
+}
+
+/**
+ * Decode a DER OBJECT IDENTIFIER body to dotted form.
+ * @param {Buffer} der
+ * @param {number} start
+ * @param {number} end
+ * @returns {string}
+ */
+function decodeOid(der, start, end) {
+    const arcs = [];
+    let value = 0;
+    for (let i = start; i < end; i++) {
+        value = value * 128 + (der[i] & 0x7f);
+        if ((der[i] & 0x80) === 0) {
+            if (arcs.length === 0) {
+                const first = value < 80 ? Math.floor(value / 40) : 2;
+                arcs.push(first, value - first * 40);
+            } else {
+                arcs.push(value);
+            }
+            value = 0;
+        }
+    }
+    return arcs.join('.');
+}
+
+/**
+ * List a certificate's extensions from its DER: the [3] EXPLICIT element of
+ * the TBSCertificate, each entry a SEQUENCE of OID, optional critical
+ * BOOLEAN, and an OCTET STRING value.
+ * @param {Buffer} der
+ * @returns {Array<{ oid: string, critical: boolean, value: Buffer }>}
+ */
+function readExtensions(der) {
+    const certificate = readElement(der, 0);
+    const tbs = readElement(der, certificate.start);
+    const extensions = [];
+    let offset = tbs.start;
+    while (offset < tbs.end) {
+        const field = readElement(der, offset);
+        if (field.tag === 0xa3) {
+            const list = readElement(der, field.start);
+            let position = list.start;
+            while (position < list.end) {
+                const entry = readElement(der, position);
+                const oid = readElement(der, entry.start);
+                let next = readElement(der, oid.end);
+                let critical = false;
+                if (next.tag === 0x01) {
+                    critical = der[next.start] !== 0;
+                    next = readElement(der, next.end);
+                }
+                extensions.push({
+                    oid: decodeOid(der, oid.start, oid.end),
+                    critical,
+                    value: der.subarray(next.start, next.end),
+                });
+                position = entry.end;
+            }
+            break;
+        }
+        offset = field.end;
+    }
+    return extensions;
+}
+
+/**
+ * The pathLenConstraint from basicConstraints, or undefined when absent.
+ * @param {Array<{ oid: string, value: Buffer }>} extensions
+ * @returns {number | undefined}
+ */
+function pathLengthConstraint(extensions) {
+    const basic = extensions.find((extension) => extension.oid === BASIC_CONSTRAINTS_OID);
+    if (!basic) {
+        return undefined;
+    }
+    const sequence = readElement(basic.value, 0);
+    let offset = sequence.start;
+    while (offset < sequence.end) {
+        const field = readElement(basic.value, offset);
+        if (field.tag === 0x02) {
+            let length = 0;
+            for (let i = field.start; i < field.end; i++) {
+                length = length * 256 + basic.value[i];
+            }
+            return length;
+        }
+        offset = field.end;
+    }
+    return undefined;
+}
+
+/**
+ * The first byte of the keyUsage BIT STRING (digitalSignature is its high
+ * bit), or undefined when the extension is absent.
+ * @param {Array<{ oid: string, value: Buffer }>} extensions
+ * @returns {number | undefined}
+ */
+function keyUsageBits(extensions) {
+    const usage = extensions.find((extension) => extension.oid === KEY_USAGE_OID);
+    if (!usage) {
+        return undefined;
+    }
+    const bits = readElement(usage.value, 0);
+    return usage.value[bits.start + 1];
+}
+
+/**
+ * Canonical form of a rendered distinguished name for self-issued detection:
+ * ASCII-space runs collapsed and ASCII letters case folded per RDN, matching
+ * what OpenSSL's canonical name comparison folds. Unicode spaces and letters
+ * outside A-Z are left intact, so names differing only by a non-breaking space
+ * or by a character such as U+212A KELVIN SIGN are not folded into a match,
+ * which would drop a real intermediate from the path-length count.
+ * An empty DN renders as undefined and canonicalizes to ''.
+ * @param {string | undefined} name
+ * @returns {string}
+ */
+function canonicalName(name) {
+    return (name ?? '').split('\n').map((rdn) => rdn.replace(/ +/g, ' ').replace(/^ | $/g, '').replace(/[A-Z]/g, (letter) => letter.toLowerCase())).join('\n');
+}
+
+/**
+ * @typedef {{ x509: X509Certificate, pathLen: number | undefined, keyUsage: number | undefined, selfIssued: boolean, unsupported: { oid: string, critical: boolean } | undefined }} PathCertificate
+ */
+
+/**
+ * Parse the fields the path check needs from a certificate.
+ * @param {X509Certificate} x509
+ * @returns {PathCertificate}
+ */
+function inspect(x509) {
+    const extensions = readExtensions(x509.raw);
+    const unsupported = extensions.find((extension) =>
+        UNPROCESSED_CONSTRAINTS.has(extension.oid) || (extension.critical && !PROCESSED_EXTENSIONS.has(extension.oid))
+    );
+    return {
+        x509,
+        pathLen: pathLengthConstraint(extensions),
+        keyUsage: keyUsageBits(extensions),
+        selfIssued: canonicalName(x509.subject) === canonicalName(x509.issuer),
+        unsupported: unsupported && { oid: unsupported.oid, critical: unsupported.critical },
+    };
+}
+
+/**
+ * The individual CA certificates one `caCertificates` entry carries. A PEM
+ * bundle contributes every block it holds; DER and unparseable input are
+ * passed through for X509Certificate to accept or reject.
+ * @param {string | Buffer} ca
+ * @returns {Array<string | Buffer>}
+ */
+function toAnchorCertificates(ca) {
+    const text = Buffer.isBuffer(ca) ? ca.toString('latin1') : ca;
+    const blocks = splitPemBlocks(text);
+    // X509Certificate reads only the first certificate of a blob, so any block
+    // carrying a label splitPemBlocks does not recognize (OpenSSL's TRUSTED
+    // CERTIFICATE among them) drops out of a multi-block bundle unnoticed. One
+    // such block on its own still reaches X509Certificate whole.
+    const present = (text.match(/-----BEGIN [^-\n]*CERTIFICATE-----/g) || []).length;
+    if (present > Math.max(blocks.length, 1)) {
+        throw new Error('client-certificate-auth: allowCA could not split this PEM bundle; pass each certificate as its own entry');
+    }
+    return blocks.length > 0 ? blocks : [ca];
+}
+
+/**
+ * Whether a CA's pathLenConstraint permits `intermediates` non-self-issued CA
+ * certificates below it.
+ * @param {PathCertificate} ca
+ * @param {number} intermediates
+ * @returns {boolean}
+ */
+function permitsPathLength(ca, intermediates) {
+    return ca.pathLen === undefined || ca.pathLen >= intermediates;
+}
+
+/**
+ * A certificate carrying an Extended Key Usage extension must list
+ * clientAuth; one without the extension is unrestricted. Node exposes the
+ * extension's OIDs as `keyUsage`.
+ * @param {X509Certificate} x509
+ * @returns {boolean}
+ */
+function permitsClientAuth(x509) {
+    const extendedKeyUsage = x509.keyUsage;
+    return extendedKeyUsage === undefined || extendedKeyUsage.includes(CLIENT_AUTH_OID);
+}
+
+/**
+ * Create a validation callback that accepts certificates issued by one of the
+ * given CA certificates, directly or through the `issuerCertificate` chain
+ * attached with `includeChain: true`.
+ *
+ * It performs the subset of PKIX path validation that applies to a forwarded
+ * client certificate: issuer name and signature at every link, keyUsage
+ * keyCertSign where an issuer carries the extension, basicConstraints cA on
+ * every CA including the anchor, pathLenConstraint counting non-self-issued
+ * intermediates, clientAuth in the Extended Key Usage of every certificate on
+ * the path that carries one, digitalSignature or keyAgreement in the leaf's
+ * keyUsage when present, validity windows on every certificate, and rejection
+ * of any certificate carrying name constraints at any criticality or any
+ * other critical extension it does not process, so a name-constrained or
+ * policy-constrained intermediate anywhere in the chain fails the check. It
+ * does not process name constraints or certificate policies, and does not
+ * check revocation. Where the proxy can validate the client certificate
+ * itself, prefer that.
+ *
+ * This establishes trust for passthrough presets (`aws-alb`,
+ * `azure-app-service`), where the proxy forwards the presented certificate
+ * without validating it. Anchors must be CA certificates that permit
+ * clientAuth; intermediates may be listed alongside roots to trust them
+ * directly, and a specific leaf is pinned with `allowFingerprints` instead.
+ * Throws at construction if a CA certificate cannot be parsed, is not a CA,
+ * does not permit clientAuth, carries name constraints or an unsupported
+ * critical extension, or sits in a PEM bundle whose blocks cannot all be read,
+ * and if `maxDepth` is not a positive integer.
+ *
+ * @param {string | Buffer | Array<string | Buffer>} caCertificates - PEM or DER encoded CA certificates; a PEM bundle contributes every certificate it holds
+ * @param {{ maxDepth?: number }} [options] - `maxDepth` bounds the number of certificates walked, leaf included (default 10)
+ * @returns {ValidationCallback}
+ *
+ * @example
+ * app.use(clientCertificateAuth(allowCA(readFileSync('ca.pem')), {
+ *   certificateSource: 'aws-alb',
+ *   includeChain: true
+ * }));
+ */
+export function allowCA(caCertificates, options = {}) {
+    const anchors = toArray(caCertificates).flatMap(toAnchorCertificates).map((ca) => inspect(new X509Certificate(ca)));
+    for (const anchor of anchors) {
+        const name = anchor.x509.subject;
+        if (anchor.unsupported) {
+            const kind = anchor.unsupported.critical ? 'critical extension' : 'extension';
+            throw new Error(`client-certificate-auth: allowCA CA certificate '${name}' carries unsupported ${kind} ${anchor.unsupported.oid}`);
+        }
+        if (!anchor.x509.ca) {
+            throw new Error(`client-certificate-auth: allowCA CA certificate '${name}' is not usable as a CA certificate (needs basicConstraints cA, and keyCertSign where keyUsage is present)`);
+        }
+        if (!permitsClientAuth(anchor.x509)) {
+            throw new Error(`client-certificate-auth: allowCA CA certificate '${name}' does not permit clientAuth in its extended key usage`);
+        }
+    }
+    const { maxDepth = 10 } = options;
+    if (!Number.isInteger(maxDepth) || maxDepth < 1) {
+        throw new Error('client-certificate-auth: allowCA maxDepth must be a positive integer');
+    }
+    if (anchors.length === 0) {return () => false;}
+
+    return (/** @type {import('./parsers.js').ChainedPeerCertificate} */ cert) => {
+        const now = Date.now();
+        const leaf = toX509(cert);
+        if (!leaf) {return false;}
+        let subject = inspect(leaf);
+        if (subject.keyUsage !== undefined && (subject.keyUsage & (KU_DIGITAL_SIGNATURE | KU_KEY_AGREEMENT)) === 0) {return false;}
+        let current = cert;
+        let intermediates = 0;
+        for (let depth = 0; depth < maxDepth; depth++) {
+            if (subject.unsupported || !permitsClientAuth(subject.x509) || !withinValidity(subject.x509, now)) {return false;}
+            if (anchors.some((ca) => withinValidity(ca.x509, now) && permitsPathLength(ca, intermediates) && issuedBy(subject.x509, ca.x509))) {
+                return true;
+            }
+            const issuer = current.issuerCertificate;
+            if (!issuer || issuer === current) {return false;}
+            const issuerX509 = toX509(issuer);
+            if (!issuerX509 || !issuerX509.ca || !issuedBy(subject.x509, issuerX509)) {return false;}
+            const link = inspect(issuerX509);
+            if (!permitsPathLength(link, intermediates)) {return false;}
+            if (!link.selfIssued) {intermediates++;}
+            current = issuer;
+            subject = link;
+        }
         return false;
     };
 }

--- a/lib/parsers.d.ts
+++ b/lib/parsers.d.ts
@@ -124,6 +124,12 @@ export declare function parseHeaderValue(
 ): ChainedPeerCertificate | null;
 
 /**
+ * Split a string of concatenated PEM CERTIFICATE blocks into individual PEM
+ * strings. Returns an empty array when the input holds no CERTIFICATE block.
+ */
+export declare function splitPemBlocks(pem: string): string[];
+
+/**
  * Get certificate from request headers using configuration.
  */
 export declare function getCertificateFromHeaders(

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -138,7 +138,7 @@ export function parseUrlPem(headerValue) {
  * @param {string} pem - Concatenated PEM blocks
  * @returns {string[]} Individual PEM blocks (empty array if none found)
  */
-function splitPemBlocks(pem) {
+export function splitPemBlocks(pem) {
     // Stryker disable next-line ArrayDeclaration: sentinel-array mutant pushes a non-PEM string that pemToCertificate rejects and .filter(Boolean) drops downstream — same chain output
     const blocks = [];
     // Stryker disable next-line StringLiteral: empty beginMarker → indexOf returns scanPos every iteration; END markers still bracket the same blocks correctly

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",
         "@eslint/js": "^10.0.1",
+        "@peculiar/x509": "^1.14.3",
         "@stryker-mutator/core": "^9.6.0",
         "@stryker-mutator/jest-runner": "^9.6.1",
         "@types/express": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@commitlint/cli": "^21.0.0",
     "@commitlint/config-conventional": "^21.0.0",
     "@eslint/js": "^10.0.1",
+    "@peculiar/x509": "^1.14.3",
     "@stryker-mutator/core": "^9.6.0",
     "@stryker-mutator/jest-runner": "^9.6.1",
     "@types/express": "^5.0.6",

--- a/test/test-typescript-types.ts
+++ b/test/test-typescript-types.ts
@@ -338,6 +338,15 @@ const _chainInHooks = clientCertificateAuth(() => true, {
     onRejected: (cert) => void cert?.issuerCertificate?.subject,
 });
 
+// Test 28: allowCA accepts PEM strings, DER buffers, and arrays of either
+import { allowCA } from '../lib/helpers.js';
+declare const caPem: string;
+declare const caDer: Buffer;
+const _allowCaPem = clientCertificateAuth(allowCA(caPem), { includeChain: true });
+const _allowCaMixed = clientCertificateAuth(allowCA([caDer, caPem], { maxDepth: 3 }));
+void _allowCaPem;
+void _allowCaMixed;
+
 // Suppress unused variable warnings - this file is for type-checking only
 void _statusCode;
 void _syncMiddleware;

--- a/test/test-unit-helpers.cjs
+++ b/test/test-unit-helpers.cjs
@@ -23,6 +23,7 @@ describe('helpers (CommonJS wrapper)', () => {
     it('should export all expected helper functions', async () => {
         const mod = await helpers.load();
         const expectedFunctions = [
+            'allowCA',
             'allowCN',
             'allowFingerprints',
             'allowIssuer',

--- a/test/test-unit-helpers.js
+++ b/test/test-unit-helpers.js
@@ -9,9 +9,52 @@ import {
     allowSerial,
     allowSAN,
     allowEmail,
+    allowCA,
     allOf,
     anyOf,
 } from '../lib/helpers.js';
+import { pemToCertificate } from '../lib/parsers.js';
+import { generateMtlsCertificates, generateIntermediateChain, generateClientCertificate, pemToDer } from './test-helpers.js';
+import selfsigned from 'selfsigned';
+import * as x509 from '@peculiar/x509';
+import { webcrypto } from 'node:crypto';
+
+const RSA_SHA256 = { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' };
+
+/**
+ * Issue a certificate with arbitrary extensions, signed by a selfsigned-style
+ * CA ({ cert, key } PEM pair), or self-signed when `ca` is null. Returns the
+ * PEM certificate and its PKCS#8 private key.
+ */
+async function issueWithExtensions(ca, commonName, extensions) {
+    const keys = await webcrypto.subtle.generateKey({ ...RSA_SHA256, modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) }, true, ['sign', 'verify']);
+    const validity = { notBefore: new Date(Date.now() - 60_000), notAfter: new Date(Date.now() + 86_400_000) };
+    let cert;
+    if (ca) {
+        const pkcs8 = Buffer.from(ca.key.replace(/-----[A-Z ]+-----/g, '').replace(/\s+/g, ''), 'base64');
+        const signingKey = await webcrypto.subtle.importKey('pkcs8', pkcs8, RSA_SHA256, false, ['sign']);
+        cert = await x509.X509CertificateGenerator.create({
+            ...validity,
+            subject: commonName ? `CN=${commonName}` : '',
+            issuer: new x509.X509Certificate(ca.cert).subject,
+            signingAlgorithm: RSA_SHA256,
+            publicKey: keys.publicKey,
+            signingKey,
+            extensions,
+        });
+    } else {
+        cert = await x509.X509CertificateGenerator.createSelfSigned({
+            ...validity,
+            name: `CN=${commonName}`,
+            signingAlgorithm: RSA_SHA256,
+            keys,
+            extensions,
+        });
+    }
+    const der = Buffer.from(await webcrypto.subtle.exportKey('pkcs8', keys.privateKey));
+    const key = `-----BEGIN PRIVATE KEY-----\n${der.toString('base64').match(/.{1,64}/g).join('\n')}\n-----END PRIVATE KEY-----\n`;
+    return { cert: cert.toString('pem'), key };
+}
 
 // Mock certificate for testing
 const mockCert = {
@@ -703,6 +746,441 @@ describe('helpers', () => {
             };
             const check = allowEmail(['other@example.com']);
             assert.equal(check(cert), false);
+        });
+    });
+
+    describe('allowCA', () => {
+        let pki;        // root CA + client signed by it
+        let chain;      // intermediate signed by pki.ca + client signed by the intermediate
+        let lookalike;  // a second CA with the same subject DN but a different key
+        let selfSigned;
+        let expired;
+        let notYetValid;
+        let expiredCa;
+
+        const day = 24 * 60 * 60 * 1000;
+        const signedBy = (ca, commonName, dates = {}) => selfsigned.generate(
+            [{ name: 'commonName', value: commonName }],
+            {
+                algorithm: 'sha256',
+                keySize: 2048,
+                notBeforeDate: new Date(Date.now() - 60_000),
+                ...dates,
+                ...(ca ? { ca: { key: ca.key, cert: ca.cert } } : {}),
+                extensions: [{ name: 'basicConstraints', cA: !ca, critical: true }],
+            }
+        );
+
+        beforeAll(async () => {
+            pki = await generateMtlsCertificates();
+            chain = await generateIntermediateChain(pki.ca);
+            lookalike = await generateMtlsCertificates({ caCommonName: 'Test CA' });
+            selfSigned = await generateClientCertificate('Self Signed');
+            expired = await signedBy(pki.ca, 'Expired', { notBeforeDate: new Date(Date.now() - 2 * day), notAfterDate: new Date(Date.now() - day) });
+            notYetValid = await signedBy(pki.ca, 'Future', { notBeforeDate: new Date(Date.now() + day), notAfterDate: new Date(Date.now() + 2 * day) });
+            const oldCa = await signedBy(null, 'Old CA', { notBeforeDate: new Date(Date.now() - 2 * day), notAfterDate: new Date(Date.now() - day) });
+            expiredCa = { ca: { cert: oldCa.cert, key: oldCa.private }, client: await signedBy({ cert: oldCa.cert, key: oldCa.private }, 'Client Of Old CA') };
+        }, 60_000);
+
+        it('should accept a certificate issued directly by a configured CA', () => {
+            const cert = pemToCertificate(pki.client.cert);
+            assert.equal(allowCA(pki.ca.cert)(cert), true);
+            assert.equal(allowCA([pki.ca.cert])(cert), true);
+            assert.equal(allowCA(pemToDer(pki.ca.cert))(cert), true);
+        });
+
+        it('should reject a self-signed certificate', () => {
+            assert.equal(allowCA(pki.ca.cert)(pemToCertificate(selfSigned.cert)), false);
+        });
+
+        it('should reject a certificate from a CA with the same subject name but a different key', () => {
+            const cert = pemToCertificate(lookalike.client.cert);
+            assert.equal(cert.issuer.CN, 'Test CA');
+            assert.equal(allowCA(pki.ca.cert)(cert), false);
+        });
+
+        it('should walk the issuerCertificate chain to a configured root', () => {
+            const leaf = pemToCertificate(chain.client.cert);
+            assert.equal(allowCA(pki.ca.cert)(leaf), false);
+
+            leaf.issuerCertificate = pemToCertificate(chain.intermediate.cert);
+            assert.equal(allowCA(pki.ca.cert)(leaf), true);
+        });
+
+        it('should trust an intermediate listed as an anchor without the root', () => {
+            const leaf = pemToCertificate(chain.client.cert);
+            assert.equal(allowCA(chain.intermediate.cert)(leaf), true);
+        });
+
+        it('should reject a chain link through a certificate that is not a CA', async () => {
+            const leaf = await signedBy(pki.ca, 'Mallory');
+            const forged = await signedBy({ cert: leaf.cert, key: leaf.private }, 'admin');
+            assert.equal(allowCA(pki.ca.cert)(pemToCertificate(leaf.cert)), true);
+
+            const cert = pemToCertificate(forged.cert);
+            cert.issuerCertificate = pemToCertificate(leaf.cert);
+            assert.equal(allowCA(pki.ca.cert)(cert), false);
+        });
+
+        it('should require clientAuth when the leaf carries an extended key usage', async () => {
+            const withEku = (usage) => selfsigned.generate([{ name: 'commonName', value: usage }], {
+                algorithm: 'sha256',
+                keySize: 2048,
+                notBeforeDate: new Date(Date.now() - 60_000),
+                ca: { key: pki.ca.key, cert: pki.ca.cert },
+                extensions: [
+                    { name: 'basicConstraints', cA: false, critical: true },
+                    { name: 'extKeyUsage', [usage]: true },
+                ],
+            });
+            const serverOnly = await withEku('serverAuth');
+            const client = await withEku('clientAuth');
+
+            assert.equal(allowCA(pki.ca.cert)(pemToCertificate(serverOnly.cert)), false);
+            assert.equal(allowCA(pki.ca.cert)(pemToCertificate(client.cert)), true);
+        });
+
+        const signedCa = (ca, commonName, pathLenConstraint) => selfsigned.generate(
+            [{ name: 'commonName', value: commonName }],
+            {
+                algorithm: 'sha256',
+                keySize: 2048,
+                notBeforeDate: new Date(Date.now() - 60_000),
+                ...(ca ? { ca: { key: ca.key, cert: ca.cert } } : {}),
+                extensions: [
+                    { name: 'basicConstraints', cA: true, critical: true, ...(pathLenConstraint === undefined ? {} : { pathLenConstraint }) },
+                    { name: 'keyUsage', keyCertSign: true, cRLSign: true, critical: true },
+                ],
+            }
+        );
+        const asCa = (generated) => ({ cert: generated.cert, key: generated.private });
+        const chainOf = (...pems) => {
+            const certs = pems.map(pemToCertificate);
+            for (let i = 0; i < certs.length - 1; i++) {
+                certs[i].issuerCertificate = certs[i + 1];
+            }
+            return certs[0];
+        };
+
+        it('should enforce pathLenConstraint on intermediates', async () => {
+            const limited = await signedCa(pki.ca, 'Limited Intermediate', 0);
+            const subCa = await signedCa(asCa(limited), 'Sub CA');
+            const deep = await signedBy(asCa(subCa), 'Deep Leaf');
+            assert.equal(allowCA(pki.ca.cert)(chainOf(deep.cert, subCa.cert, limited.cert)), false);
+
+            const shallow = await signedBy(asCa(limited), 'Shallow Leaf');
+            assert.equal(allowCA(pki.ca.cert)(chainOf(shallow.cert, limited.cert)), true);
+        });
+
+        it('should count a rollover intermediate whose names differ only by whitespace encoding', async () => {
+            // Root name carries a non-breaking space, the intermediate an ASCII
+            // space: they render identically but the DER Names differ, so the
+            // intermediate is not self-issued and must count toward the path length.
+            const NBSP = '\u00a0';
+            const bc = (ca, pathLen) => new x509.BasicConstraintsExtension(ca, pathLen, true);
+            const root = await issueWithExtensions(null, `Rollover${NBSP}CA`, [bc(true, 0)]);
+            const intermediate = await issueWithExtensions(root, 'Rollover CA', [bc(true, undefined)]);
+            const leaf = await issueWithExtensions(intermediate, 'Rollover Leaf', [bc(false, undefined)]);
+            assert.equal(allowCA(root.cert)(chainOf(leaf.cert, intermediate.cert, root.cert)), false);
+
+            const roomier = await issueWithExtensions(null, `Rollover${NBSP}CA`, [bc(true, 1)]);
+            const under = await issueWithExtensions(roomier, 'Rollover CA', [bc(true, undefined)]);
+            const underLeaf = await issueWithExtensions(under, 'Rollover Leaf', [bc(false, undefined)]);
+            assert.equal(allowCA(roomier.cert)(chainOf(underLeaf.cert, under.cert, roomier.cert)), true);
+        });
+
+        it('should count a rollover intermediate whose name differs only by Unicode case', async () => {
+            // U+212A KELVIN SIGN lowercases to 'k' in Unicode but not in the
+            // ASCII-only fold X.509 canonical name comparison applies, so the
+            // intermediate is not self-issued and must count toward the path length.
+            const KELVIN = '\u212a';
+            const bc = (ca, pathLen) => new x509.BasicConstraintsExtension(ca, pathLen, true);
+            const root = await issueWithExtensions(null, 'Rollover KA', [bc(true, 0)]);
+            const intermediate = await issueWithExtensions(root, `Rollover ${KELVIN}A`, [bc(true, undefined)]);
+            const leaf = await issueWithExtensions(intermediate, 'Rollover Leaf', [bc(false, undefined)]);
+            assert.equal(allowCA(root.cert)(chainOf(leaf.cert, intermediate.cert, root.cert)), false);
+
+            const roomier = await issueWithExtensions(null, 'Rollover KA', [bc(true, 1)]);
+            const under = await issueWithExtensions(roomier, `Rollover ${KELVIN}A`, [bc(true, undefined)]);
+            const underLeaf = await issueWithExtensions(under, 'Rollover Leaf', [bc(false, undefined)]);
+            assert.equal(allowCA(roomier.cert)(chainOf(underLeaf.cert, under.cert, roomier.cert)), true);
+        });
+
+        it('should not count a genuine rollover intermediate that is self-issued', async () => {
+            const bc = (ca, pathLen) => new x509.BasicConstraintsExtension(ca, pathLen, true);
+            const root = await issueWithExtensions(null, 'Rollover CA', [bc(true, 0)]);
+            const rollover = await issueWithExtensions(root, 'Rollover CA', [bc(true, undefined)]);
+            const leaf = await issueWithExtensions(rollover, 'Rollover Leaf', [bc(false, undefined)]);
+            assert.equal(allowCA(root.cert)(chainOf(leaf.cert, rollover.cert, root.cert)), true);
+        });
+
+        it('should enforce pathLenConstraint on the anchor', async () => {
+            const root = await signedCa(null, 'Shallow Root', 0);
+            const intermediate = await signedCa(asCa(root), 'Intermediate Under Shallow Root');
+            const twoDeep = await signedBy(asCa(intermediate), 'Two Deep');
+            assert.equal(allowCA(root.cert)(chainOf(twoDeep.cert, intermediate.cert)), false);
+
+            const direct = await signedBy(asCa(root), 'Direct');
+            assert.equal(allowCA(root.cert)(pemToCertificate(direct.cert)), true);
+        });
+
+        it('should reject an intermediate whose keyUsage lacks keyCertSign', async () => {
+            const signer = await selfsigned.generate([{ name: 'commonName', value: 'No CertSign' }], {
+                algorithm: 'sha256',
+                keySize: 2048,
+                notBeforeDate: new Date(Date.now() - 60_000),
+                ca: { key: pki.ca.key, cert: pki.ca.cert },
+                extensions: [
+                    { name: 'basicConstraints', cA: true, critical: true },
+                    { name: 'keyUsage', digitalSignature: true, critical: true },
+                ],
+            });
+            const leaf = await signedBy(asCa(signer), 'Leaf Of No CertSign');
+            assert.equal(allowCA(pki.ca.cert)(chainOf(leaf.cert, signer.cert)), false);
+        });
+
+        it('should reject certificates carrying a critical extension it does not process', async () => {
+            const unknownCritical = new x509.Extension('1.3.6.1.4.1.99999.1', true, new Uint8Array([0x05, 0x00]));
+            const unknownNonCritical = new x509.Extension('1.3.6.1.4.1.99999.1', false, new Uint8Array([0x05, 0x00]));
+
+            const leaf = await issueWithExtensions(pki.ca, 'Critical Leaf', [unknownCritical]);
+            assert.equal(allowCA(pki.ca.cert)(pemToCertificate(leaf.cert)), false);
+
+            const tolerated = await issueWithExtensions(pki.ca, 'Tolerated Leaf', [unknownNonCritical]);
+            assert.equal(allowCA(pki.ca.cert)(pemToCertificate(tolerated.cert)), true);
+
+            const intermediate = await issueWithExtensions(pki.ca, 'Critical Intermediate', [
+                new x509.BasicConstraintsExtension(true, undefined, true),
+                new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyCertSign, true),
+                unknownCritical,
+            ]);
+            const underIntermediate = await signedBy(intermediate, 'Under Critical Intermediate');
+            assert.equal(allowCA(pki.ca.cert)(chainOf(underIntermediate.cert, intermediate.cert)), false);
+
+            const root = await issueWithExtensions(null, 'Critical Root', [unknownCritical]);
+            assert.throws(() => allowCA(root.cert), /unsupported critical extension 1\.3\.6\.1\.4\.1\.99999\.1/);
+        });
+
+        it('should reject unprocessed extensions by OID when critical and tolerate them otherwise', async () => {
+            const bodies = {
+                // CertificatePolicies { PolicyInformation { anyPolicy } }
+                '2.5.29.32': '300830060604551d2000',
+                // CRLDistributionPoints { DistributionPoint { fullName { URI http://crl.test/ca.crl } } }
+                '2.5.29.31': '301e301ca01aa0188616687474703a2f2f63726c2e746573742f63612e63726c',
+                // IssuerAltName { URI http://ca.test }
+                '2.5.29.18': '3010860e687474703a2f2f63612e74657374',
+                // AuthorityInfoAccess { AccessDescription { id-ad-ocsp, URI http://ocsp.test } }
+                '1.3.6.1.5.5.7.1.1': '301e301c06082b060105050730018610687474703a2f2f6f6373702e74657374',
+            };
+            for (const [oid, hex] of Object.entries(bodies)) {
+                const value = Buffer.from(hex, 'hex');
+                const rejected = await issueWithExtensions(pki.ca, `Critical ${oid}`, [new x509.Extension(oid, true, value)]);
+                assert.equal(allowCA(pki.ca.cert)(pemToCertificate(rejected.cert)), false, oid);
+                const tolerated = await issueWithExtensions(pki.ca, `Tolerated ${oid}`, [new x509.Extension(oid, false, value)]);
+                assert.equal(allowCA(pki.ca.cert)(pemToCertificate(tolerated.cert)), true, oid);
+            }
+
+            const policyRoot = await issueWithExtensions(null, 'Policy Root', [
+                new x509.BasicConstraintsExtension(true, undefined, true),
+                new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyCertSign, true),
+                new x509.Extension('2.5.29.32', true, Buffer.from(bodies['2.5.29.32'], 'hex')),
+            ]);
+            assert.throws(() => allowCA(policyRoot.cert), /unsupported critical extension 2\.5\.29\.32/);
+        });
+
+        it('should accept a leaf with an empty subject and a critical subjectAltName', async () => {
+            const workload = await issueWithExtensions(pki.ca, '', [
+                new x509.SubjectAlternativeNameExtension([{ type: 'url', value: 'spiffe://example.org/workload' }], true),
+            ]);
+            assert.equal(allowCA(pki.ca.cert)(pemToCertificate(workload.cert)), true);
+        });
+
+        it('should require clientAuth in the extended key usage of intermediates too', async () => {
+            const caExtensions = (usage) => [
+                new x509.BasicConstraintsExtension(true, undefined, true),
+                new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyCertSign, true),
+                new x509.ExtendedKeyUsageExtension([usage], true),
+            ];
+            const serverCa = await issueWithExtensions(pki.ca, 'Server CA', caExtensions(x509.ExtendedKeyUsage.serverAuth));
+            const underServerCa = await signedBy(serverCa, 'Under Server CA');
+            assert.equal(allowCA(pki.ca.cert)(chainOf(underServerCa.cert, serverCa.cert)), false);
+
+            const clientCa = await issueWithExtensions(pki.ca, 'Client CA', caExtensions(x509.ExtendedKeyUsage.clientAuth));
+            const underClientCa = await signedBy(clientCa, 'Under Client CA');
+            assert.equal(allowCA(pki.ca.cert)(chainOf(underClientCa.cert, clientCa.cert)), true);
+        });
+
+        it('should require digitalSignature or keyAgreement in the leaf keyUsage when present', async () => {
+            const encipherOnly = await issueWithExtensions(pki.ca, 'Encipher Leaf', [
+                new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyEncipherment, true),
+                new x509.ExtendedKeyUsageExtension([x509.ExtendedKeyUsage.clientAuth]),
+            ]);
+            assert.equal(allowCA(pki.ca.cert)(pemToCertificate(encipherOnly.cert)), false);
+
+            const agreement = await issueWithExtensions(pki.ca, 'Agreement Leaf', [
+                new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyAgreement, true),
+            ]);
+            assert.equal(allowCA(pki.ca.cert)(pemToCertificate(agreement.cert)), true);
+            assert.equal(allowCA(pki.ca.cert)(pemToCertificate(pki.client.cert)), true);
+        });
+
+        it('should reject anchors that are not CA certificates or do not permit clientAuth', async () => {
+            assert.throws(() => allowCA(pki.client.cert), /is not usable as a CA certificate/);
+
+            const serverRoot = await issueWithExtensions(null, 'Server Root', [
+                new x509.BasicConstraintsExtension(true, undefined, true),
+                new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyCertSign, true),
+                new x509.ExtendedKeyUsageExtension([x509.ExtendedKeyUsage.serverAuth], true),
+            ]);
+            assert.throws(() => allowCA(serverRoot.cert), /does not permit clientAuth/);
+        });
+
+        it('should not count self-issued rollover certificates toward pathLenConstraint', async () => {
+            const root = await signedCa(null, 'Rollover Root', 1);
+            const rollover = await signedCa(asCa(root), 'Rollover Root');
+            const subCa = await signedCa(asCa(rollover), 'Rollover Sub CA');
+            const leaf = await signedBy(asCa(subCa), 'Rollover Leaf');
+            assert.equal(allowCA(root.cert)(chainOf(leaf.cert, subCa.cert, rollover.cert)), true);
+        });
+
+        it('should reject name constraints at any criticality', async () => {
+            // NameConstraints { permittedSubtrees [0] { GeneralSubtree { dNSName "allowed.test" } } }
+            const nameConstraints = Buffer.concat([Buffer.from([0x30, 0x12, 0xa0, 0x10, 0x30, 0x0e, 0x82, 0x0c]), Buffer.from('allowed.test')]);
+            for (const critical of [false, true]) {
+                const constrained = await issueWithExtensions(pki.ca, 'Constrained CA', [
+                    new x509.BasicConstraintsExtension(true, undefined, true),
+                    new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyCertSign, true),
+                    new x509.Extension('2.5.29.30', critical, nameConstraints),
+                ]);
+                const leaf = await signedBy(constrained, 'evil.test');
+                assert.equal(allowCA(pki.ca.cert)(chainOf(leaf.cert, constrained.cert)), false);
+                const named = critical ? /unsupported critical extension 2\.5\.29\.30/ : /unsupported extension 2\.5\.29\.30/;
+                assert.throws(() => allowCA(constrained.cert), named);
+            }
+        });
+
+        it('should detect self-issued rollover certificates by canonical name', async () => {
+            const root = await signedCa(null, 'rollover root', 1);
+            const rollover = await signedCa(asCa(root), 'ROLLOVER  ROOT');
+            const subCa = await signedCa(asCa(rollover), 'Rollover Sub CA 2');
+            const leaf = await signedBy(asCa(subCa), 'Rollover Leaf 2');
+            assert.equal(allowCA(root.cert)(chainOf(leaf.cert, subCa.cert, rollover.cert)), true);
+        });
+
+        it('should throw at construction when maxDepth is not a positive integer', () => {
+            for (const maxDepth of [0, -1, 1.5, 'ten', Infinity]) {
+                assert.throws(() => allowCA(pki.ca.cert, { maxDepth }), /maxDepth must be a positive integer/);
+            }
+        });
+
+        it('should reject a chain whose link does not verify', () => {
+            const leaf = pemToCertificate(chain.client.cert);
+            leaf.issuerCertificate = pemToCertificate(lookalike.ca.cert);
+            assert.equal(allowCA([pki.ca.cert, lookalike.ca.cert])(leaf), false);
+        });
+
+        it('should stop at a self-referencing root', () => {
+            const cert = pemToCertificate(selfSigned.cert);
+            cert.issuerCertificate = cert;
+            assert.equal(allowCA(pki.ca.cert)(cert), false);
+        });
+
+        it('should reject expired and not-yet-valid certificates', () => {
+            assert.equal(allowCA(pki.ca.cert)(pemToCertificate(expired.cert)), false);
+            assert.equal(allowCA(pki.ca.cert)(pemToCertificate(notYetValid.cert)), false);
+        });
+
+        it('should reject a certificate issued by an expired CA', () => {
+            assert.equal(allowCA(expiredCa.ca.cert)(pemToCertificate(expiredCa.client.cert)), false);
+        });
+
+        it('should stop walking at maxDepth', () => {
+            const leaf = pemToCertificate(chain.client.cert);
+            leaf.issuerCertificate = pemToCertificate(chain.intermediate.cert);
+            assert.equal(allowCA(pki.ca.cert, { maxDepth: 1 })(leaf), false);
+            assert.equal(allowCA(pki.ca.cert, { maxDepth: 2 })(leaf), true);
+        });
+
+        it('should reject certificates without parseable raw bytes', () => {
+            const check = allowCA(pki.ca.cert);
+            assert.equal(check({ subject: { CN: 'no raw' } }), false);
+            assert.equal(check({ raw: Buffer.from('not a certificate') }), false);
+
+            const leaf = pemToCertificate(chain.client.cert);
+            leaf.issuerCertificate = { subject: { CN: 'no raw' } };
+            assert.equal(check(leaf), false);
+        });
+
+        it('should return false with an empty CA list', () => {
+            assert.equal(allowCA([])(pemToCertificate(pki.client.cert)), false);
+        });
+
+        it('should trust every certificate in a PEM bundle', async () => {
+            const second = await generateMtlsCertificates({ caCommonName: 'Bundled CA' });
+            const bundle = `${pki.ca.cert}\n${second.ca.cert}`;
+            for (const input of [bundle, Buffer.from(bundle)]) {
+                const check = allowCA(input);
+                assert.equal(check(pemToCertificate(pki.client.cert)), true);
+                assert.equal(check(pemToCertificate(second.client.cert)), true);
+            }
+
+            // The first block alone must not vouch for the second CA's client.
+            assert.equal(allowCA(pki.ca.cert)(pemToCertificate(second.client.cert)), false);
+        });
+
+        it('should throw on a bundle whose PEM blocks it cannot split', async () => {
+            const second = await generateMtlsCertificates({ caCommonName: 'Trusted Label CA' });
+            const trust = (pem) => pem.replace(/BEGIN CERTIFICATE/g, 'BEGIN TRUSTED CERTIFICATE').replace(/END CERTIFICATE/g, 'END TRUSTED CERTIFICATE');
+            const bundle = `${trust(pki.ca.cert)}\n${trust(second.ca.cert)}`;
+            assert.throws(() => allowCA(bundle), /could not split this PEM bundle/);
+
+            // A single unrecognized block still reaches X509Certificate intact.
+            assert.equal(allowCA(trust(pki.ca.cert))(pemToCertificate(pki.client.cert)), true);
+
+            // A bundle mixing recognized and unrecognized labels must not drop
+            // the unrecognized one.
+            assert.throws(
+                () => allowCA(`${pki.ca.cert}\n${trust(second.ca.cert)}`),
+                /could not split this PEM bundle/
+            );
+        });
+
+        it('should name keyUsage when an anchor carries cA without keyCertSign', async () => {
+            const noCertSign = await issueWithExtensions(null, 'No CertSign Root', [
+                new x509.BasicConstraintsExtension(true, undefined, true),
+                new x509.KeyUsagesExtension(x509.KeyUsageFlags.digitalSignature, true),
+            ]);
+            assert.throws(() => allowCA(noCertSign.cert), /needs basicConstraints cA, and keyCertSign where keyUsage is present/);
+        });
+
+        it('should reject a chain through an expired or not-yet-valid intermediate', async () => {
+            const intermediateAt = (dates) => selfsigned.generate([{ name: 'commonName', value: 'Dated Intermediate' }], {
+                algorithm: 'sha256',
+                keySize: 2048,
+                ca: { key: pki.ca.key, cert: pki.ca.cert },
+                ...dates,
+                extensions: [
+                    { name: 'basicConstraints', cA: true, critical: true },
+                    { name: 'keyUsage', keyCertSign: true, cRLSign: true, critical: true },
+                ],
+            });
+
+            const current = await intermediateAt({ notBeforeDate: new Date(Date.now() - 60_000) });
+            const live = await signedBy(asCa(current), 'Leaf Of Current Intermediate');
+            assert.equal(allowCA(pki.ca.cert)(chainOf(live.cert, current.cert)), true);
+
+            // The leaf stays valid; only the intermediate's window moves.
+            const stale = await intermediateAt({ notBeforeDate: new Date(Date.now() - 2 * day), notAfterDate: new Date(Date.now() - day) });
+            const underStale = await signedBy(asCa(stale), 'Leaf Of Stale Intermediate');
+            assert.equal(allowCA(pki.ca.cert)(chainOf(underStale.cert, stale.cert)), false);
+
+            const future = await intermediateAt({ notBeforeDate: new Date(Date.now() + day), notAfterDate: new Date(Date.now() + 2 * day) });
+            const underFuture = await signedBy(asCa(future), 'Leaf Of Future Intermediate');
+            assert.equal(allowCA(pki.ca.cert)(chainOf(underFuture.cert, future.cert)), false);
+        });
+
+        it('should throw at construction when a CA certificate cannot be parsed', () => {
+            assert.throws(() => allowCA('not a certificate'));
         });
     });
 


### PR DESCRIPTION
New allowCA helper verifies the presented certificate and its issuerCertificate chain against configured CA certificates: signatures, cA and pathLen constraints, key usages, validity, and unhandled critical extensions. Revocation is out of scope.