### PR TITLE
chore(deps): drop the unused c8 devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@stryker-mutator/jest-runner": "^9.6.1",
         "@types/express": "^5.0.6",
         "@types/node": "^26.1.1",
-        "c8": "^11.0.0",
         "eslint": "^10.2.1",
         "globals": "^17.5.0",
         "husky": "^9.1.7",
@@ -896,16 +895,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@bcoe/v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@braidai/lang": {
@@ -4832,40 +4821,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/c8": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-11.0.0.tgz",
-      "integrity": "sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.1",
-        "@istanbuljs/schema": "^0.1.3",
-        "find-up": "^5.0.0",
-        "foreground-child": "^3.1.1",
-        "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.1.6",
-        "test-exclude": "^8.0.0",
-        "v8-to-istanbul": "^9.0.0",
-        "yargs": "^17.7.2",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "c8": "bin/c8.js"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "peerDependencies": {
-        "monocart-coverage-reports": "^2"
-      },
-      "peerDependenciesMeta": {
-        "monocart-coverage-reports": {
-          "optional": true
-        }
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -10239,66 +10194,6 @@
       "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/test-exclude": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
-      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@istanbuljs/schema": "^0.1.2",
-        "glob": "^13.0.6",
-        "minimatch": "^10.2.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/test-exclude/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/thenify": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "@stryker-mutator/jest-runner": "^9.6.1",
     "@types/express": "^5.0.6",
     "@types/node": "^26.1.1",
-    "c8": "^11.0.0",
     "eslint": "^10.2.1",
     "globals": "^17.5.0",
     "husky": "^9.1.7",


### PR DESCRIPTION
Nothing references c8; coverage comes from Jest.