### PR TITLE
chore(examples): refresh the e2e lockfile to client-certificate-auth 2.2.0

### DIFF
--- a/examples/e2e-mtls/package-lock.json
+++ b/examples/e2e-mtls/package-lock.json
@@ -99,9 +99,9 @@
       }
     },
     "node_modules/client-certificate-auth": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/client-certificate-auth/-/client-certificate-auth-2.1.2.tgz",
-      "integrity": "sha512-JKD3Ksi87vrwEi/BxIXR3k9HD3jEFO0mZB4RkvJ/NPGLNjW5yrGTZElI0CM1Fe3rPJZSNCBSmcvUlW1PUqRqDQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/client-certificate-auth/-/client-certificate-auth-2.2.0.tgz",
+      "integrity": "sha512-VOBOpxGh2l07pxkCXaWDFFg3AJ+VdyU68QpKS0CouzgrCpU9wg9JVUN7v9TtSmaARnAjAte0AZnrxT0+Tlv20g==",
       "license": "MIT",
       "engines": {
         "node": ">= 20"


### PR DESCRIPTION
Refreshes the e2e example lockfile to 2.2.0.