### PR TITLE
docs(api): align the ClientCertResponse typedef with the declaration

### DIFF
--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -35,7 +35,7 @@ function normalizeCallbackError(err) {
 
 /**
  * @typedef {import('http').IncomingMessage & { secure?: boolean; socket: import('net').Socket & { authorized?: boolean; authorizationError?: Error | string; getPeerCertificate?: (detailed?: boolean) => import('tls').PeerCertificate | import('tls').DetailedPeerCertificate }; clientCertificate?: import('./parsers.js').ChainedPeerCertificate }} ClientCertRequest
- * @typedef {import('http').ServerResponse & { redirect: (statusOrUrl: number | string, url?: string) => void }} ClientCertResponse
+ * @typedef {import('http').ServerResponse} ClientCertResponse
  * @typedef {(req: ClientCertRequest, res: ClientCertResponse, next: (err?: Error) => void) => void} Middleware
  */
 


### PR DESCRIPTION
Removes the redirect method from the ClientCertResponse typedef; the declaration never had it.