### PR TITLE
docs: correct the nginx snippet, the Koa example, and the CJS subpath lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ function koaClientCert(checkAuth, options = {}) {
     ctx.state.clientCertificate = result.certificate;
 
     const allowed = await checkAuth(result.certificate, ctx.req);
-    if (!allowed) {
+    if (allowed !== true) {
       ctx.throw(401, 'Certificate not authorized');
     }
 
@@ -300,6 +300,14 @@ app.post('/api/login', (req, res) => {
   res.json({ token, user });
 });
 ```
+
+### `extractClientCertificateFromLambdaEvent(event)`
+
+Exported from `client-certificate-auth/lambda`. Reads the certificate API Gateway attaches to a Lambda event (`requestContext.authentication.clientCert` for HTTP APIs, `requestContext.identity.clientCert` for REST APIs) and returns the same `{ success, certificate, reason }` result, with `lambda_event_missing_clientcert` and `lambda_event_clientcert_malformed` as the rejection reasons. See the [Lambda guide](https://tgies.github.io/client-certificate-auth/guide/lambda).
+
+### `extractClientCertificateFromRequest(request, options?)`
+
+Exported from `client-certificate-auth/fetch`. Header-only extraction for Web standard `Request` objects (Hono, Next.js route handlers, SvelteKit, Astro, Remix, Cloudflare Workers, Bun, Deno). Takes the same header options as `extractClientCertificate` and returns the same result. See the [Fetch guide](https://tgies.github.io/client-certificate-auth/guide/fetch).
 
 ### Ecosystem
 
@@ -361,7 +369,7 @@ app.use(clientCertificateAuth(allowCA(readFileSync('ca.pem')), {
 }));
 ```
 
-When `includeChain: true`, the certificate object includes `issuerCertificate` linking to the issuer's certificate (and so on up the chain). This works consistently for both socket-based and header-based extraction, except on Node.js 26.8.0 and later, where a Node.js regression ([nodejs/node#65579](https://github.com/nodejs/node/issues/65579)) leaves `issuerCertificate` unset on the socket path; header-based extraction is unaffected. See [Troubleshooting](docs/guide/troubleshooting.md#certificate-chain-missing-on-nodejs-2680-and-later).
+When `includeChain: true`, the certificate object includes `issuerCertificate` linking to the issuer's certificate (and so on up the chain) for both socket-based and header-based extraction. The chains end differently: a socket-based chain ends in a root whose `issuerCertificate` is the root itself (Node's behavior), while a header-based chain ends at the last forwarded certificate, whose `issuerCertificate` is `undefined`. Walk chains with a depth limit or a visited check rather than `while (cert.issuerCertificate)`. On Node.js 26.8.0 and later, a Node.js regression ([nodejs/node#65579](https://github.com/nodejs/node/issues/65579)) leaves `issuerCertificate` unset on the socket path, so no socket-based chain is walkable there; header-based extraction is unaffected. See [Troubleshooting](docs/guide/troubleshooting.md#certificate-chain-missing-on-nodejs-2680-and-later).
 
 For header-based extraction the first certificate in the header is the leaf. If it is empty or unparseable the header is rejected with `header_missing_or_malformed` rather than promoting the next certificate into the leaf position. A header value carries at most 10 certificates, leaf and chain header combined. See [Reverse Proxy Setup](https://tgies.github.io/client-certificate-auth/guide/reverse-proxy#chains-in-a-single-header) for the per-encoding details.
 
@@ -550,17 +558,17 @@ app.use(clientCertificateAuth(checkAuth, {
 
 Example nginx configuration:
 ```nginx
-# Strip any existing headers from clients
-proxy_set_header X-SSL-Client-Cert "";
-proxy_set_header X-SSL-Client-Verify "";
-
-# Always send verification status
-proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
-
-# Only send cert if verified
-if ($ssl_client_verify = SUCCESS) {
-    proxy_set_header X-SSL-Client-Cert $ssl_client_escaped_cert;
+# http context: expose the certificate only when nginx verified it.
+# proxy_set_header is not allowed in a server-level if block, so gate it with a map.
+map $ssl_client_verify $ssl_client_cert_if_verified {
+    SUCCESS $ssl_client_escaped_cert;
+    default "";
 }
+
+# server or location context. proxy_set_header replaces any value the client
+# sent, and an empty value removes the header entirely.
+proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
+proxy_set_header X-SSL-Client-Cert $ssl_client_cert_if_verified;
 ```
 
 ## WebSocket Support
@@ -674,7 +682,7 @@ import {
 import { readFileSync } from 'node:fs';
 ```
 
-> **Note:** In CommonJS, the `/helpers`, `/parsers`, and `/extractor` subpath exports provide a `load()` function for async access. See the [CommonJS](#commonjs) section for details.
+> **Note:** In CommonJS, the `/helpers`, `/parsers`, `/extractor`, `/lambda`, and `/fetch` subpath exports provide a `load()` function for async access. See the [CommonJS](#commonjs) section for details.
 
 ### Basic Helpers
 
@@ -844,7 +852,7 @@ The `load()` function dynamically imports the ESM module and caches it. Subseque
 
 ### Subpath Exports in CJS
 
-The `/helpers`, `/parsers`, and `/extractor` subpath exports each provide a `load()` function for async access in CommonJS. The individual functions are not synchronously available via `require()`.
+The `/helpers`, `/parsers`, `/extractor`, `/lambda`, and `/fetch` subpath exports each provide a `load()` function for async access in CommonJS. The individual functions are not synchronously available via `require()`.
 
 ```javascript
 // Helpers
@@ -877,7 +885,7 @@ The E2E tests spin up real reverse proxies, generate fresh certificates, and ver
 
 ## Security Notes
 
-- Set `rejectUnauthorized: false` on your HTTPS server to let this middleware provide helpful error messages, rather than dropping connections silently
+- Set `rejectUnauthorized: false` on your HTTPS server to let this middleware provide helpful error messages, rather than dropping connections silently. Routes that do not run the middleware then have no TLS-layer client-certificate enforcement, so apply it to every route that needs authentication
 - **When using header-based auth**, ensure your proxy strips certificate headers from external requests
 - Repeated certificate or verification header lines are rejected (Node joins repeats with `, `, so the first value would otherwise win); chain headers are RFC 9440 lists and may repeat
 - Use `verifyHeader`/`verifyValue` as defense-in-depth when using header-based authentication
@@ -987,7 +995,7 @@ const clientCertificateAuth = await require('client-certificate-auth').load();
 
 The sync CJS wrapper does not support reverse proxy options (`certificateSource`, `certificateHeader`, etc.). Passing these options will throw a descriptive error. Use `load()` to access the full ESM module from CJS code. See the [CommonJS](#commonjs) section for details.
 
-The `/helpers`, `/parsers`, and `/extractor` subpath exports each provide a `load()` function in CJS. See [Subpath Exports in CJS](#subpath-exports-in-cjs) for details.
+The `/helpers`, `/parsers`, `/extractor`, `/lambda`, and `/fetch` subpath exports each provide a `load()` function in CJS. See [Subpath Exports in CJS](#subpath-exports-in-cjs) for details.
 
 ## Commercial Support
 

--- a/docs/guide/fetch.md
+++ b/docs/guide/fetch.md
@@ -30,6 +30,8 @@ The header is the only evidence of the client's identity, so the origin must be 
 
 ::: warning Runtime requirement
 The adapter imports the core extractor, which uses `node:crypto` (`X509Certificate`). Runtimes must provide Node-compatible crypto: Node, Bun, Deno, and Cloudflare Workers with `nodejs_compat` all work. Pure edge runtimes without Node compatibility will fail at import time.
+
+TypeScript consumers need `@types/node` installed; the declarations reference `tls.PeerCertificate`.
 :::
 
 ## Recipes

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -247,7 +247,7 @@ function koaClientCert(checkAuth, options = {}) {
     ctx.state.clientCertificate = result.certificate;
 
     const allowed = await checkAuth(result.certificate, ctx.req);
-    if (!allowed) {
+    if (allowed !== true) {
       ctx.throw(401, 'Certificate not authorized');
     }
 
@@ -290,7 +290,7 @@ app.post('/api/login', (req, res) => {
 });
 ```
 
-For the full generated API reference, see the [extractor docs](/api/extractor/).
+For the full generated API reference, see the [extractor docs](/api/extractor/). The [Lambda](./lambda.md) and [Fetch](./fetch.md) adapters wrap the same extraction for API Gateway events and Web `Request` objects.
 
 ## Accessing the Certificate
 
@@ -333,7 +333,7 @@ app.use(clientCertificateAuth(allowCA(readFileSync('ca.pem')), {
 }));
 ```
 
-When `includeChain: true`, the certificate object includes `issuerCertificate` linking to the issuer's certificate (and so on up the chain). This works consistently for both socket-based and header-based extraction, except on Node.js 26.8.0 and later, where a Node.js regression ([nodejs/node#65579](https://github.com/nodejs/node/issues/65579)) leaves `issuerCertificate` unset on the socket path; header-based extraction is unaffected. See [Troubleshooting](./troubleshooting#certificate-chain-missing-on-node-js-26-8-0-and-later).
+When `includeChain: true`, the certificate object includes `issuerCertificate` linking to the issuer's certificate (and so on up the chain) for both socket-based and header-based extraction. The chains end differently: a socket-based chain ends in a root whose `issuerCertificate` is the root itself (Node's behavior), while a header-based chain ends at the last forwarded certificate, whose `issuerCertificate` is `undefined`. Walk chains with a depth limit or a visited check rather than `while (cert.issuerCertificate)`. On Node.js 26.8.0 and later, a Node.js regression ([nodejs/node#65579](https://github.com/nodejs/node/issues/65579)) leaves `issuerCertificate` unset on the socket path, so no socket-based chain is walkable there; header-based extraction is unaffected. See [Troubleshooting](./troubleshooting#certificate-chain-missing-on-node-js-26-8-0-and-later).
 
 For header-based extraction the first certificate in the header is the leaf. If it is empty or unparseable the header is rejected with `header_missing_or_malformed` rather than promoting the next certificate into the leaf position. See [Chains in a Single Header](./reverse-proxy.md#chains-in-a-single-header) for the per-encoding details.
 

--- a/docs/guide/helpers.md
+++ b/docs/guide/helpers.md
@@ -84,6 +84,8 @@ app.use(clientCertificateAuth(anyOf(
 )));
 ```
 
+Both combinators invoke every callback up front and await the results with `Promise.all`, so a `false` result or a rejected promise from one callback does not stop the others from running. A synchronous throw does: it interrupts the invocation loop before the remaining callbacks are called.
+
 These combinators accept any number of callbacks, including custom functions, so you can mix helpers with your own logic:
 
 ```javascript

--- a/docs/guide/reverse-proxy.md
+++ b/docs/guide/reverse-proxy.md
@@ -208,17 +208,17 @@ The `verifyValue` comparison is exact (case-sensitive, no whitespace trimming); 
 
 Example nginx configuration:
 ```nginx
-# Strip any existing headers from clients
-proxy_set_header X-SSL-Client-Cert "";
-proxy_set_header X-SSL-Client-Verify "";
-
-# Always send verification status
-proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
-
-# Only send cert if verified
-if ($ssl_client_verify = SUCCESS) {
-    proxy_set_header X-SSL-Client-Cert $ssl_client_escaped_cert;
+# http context: expose the certificate only when nginx verified it.
+# proxy_set_header is not allowed in a server-level if block, so gate it with a map.
+map $ssl_client_verify $ssl_client_cert_if_verified {
+    SUCCESS $ssl_client_escaped_cert;
+    default "";
 }
+
+# server or location context. proxy_set_header replaces any value the client
+# sent, and an empty value removes the header entirely.
+proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
+proxy_set_header X-SSL-Client-Cert $ssl_client_cert_if_verified;
 ```
 
 The verification header is checked before certificate parsing. If the header is absent or doesn't match the expected value, the request is rejected immediately — the certificate header is never read.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ## Security Notes
 
-- Set `rejectUnauthorized: false` on your HTTPS server to let this middleware provide helpful error messages, rather than dropping connections silently.
+- Set `rejectUnauthorized: false` on your HTTPS server to let this middleware provide helpful error messages, rather than dropping connections silently. Routes that do not run the middleware then have no TLS-layer client-certificate enforcement, so apply it to every route that needs authentication.
 - **When using header-based auth**, ensure your proxy strips certificate headers from external requests. See [Reverse Proxy Security Considerations](./reverse-proxy#security-considerations).
 - Use `verifyHeader`/`verifyValue` as defense-in-depth when using header-based authentication. See [Verification Header](./reverse-proxy#verification-header-defense-in-depth).
 
@@ -94,7 +94,7 @@ See the [WebSocket Support](./websocket) page for complete examples with both `w
 
 ## ESM vs CJS Import Differences
 
-This package is an ES module with a CJS compatibility wrapper. The sync `require()` entry only supports socket-based mTLS; reverse proxy options require the async `load()` function. Subpath exports (`/helpers`, `/extractor`, `/parsers`) also need `load()` in CJS.
+This package is an ES module with a CJS compatibility wrapper. The sync `require()` entry only supports socket-based mTLS; reverse proxy options require the async `load()` function. Subpath exports (`/helpers`, `/extractor`, `/parsers`, `/lambda`, `/fetch`) also need `load()` in CJS.
 
 For a full breakdown of what's available in each mode, see the [TypeScript & CJS](./typescript) page.
 

--- a/docs/guide/typescript.md
+++ b/docs/guide/typescript.md
@@ -96,7 +96,7 @@ The sync CJS wrapper does not support reverse proxy options. Passing these optio
 
 ### Subpath Exports in CJS
 
-The `/helpers`, `/parsers`, and `/extractor` subpath exports each provide a `load()` function for async access in CommonJS. The individual functions are not synchronously available via `require()`.
+The `/helpers`, `/parsers`, `/extractor`, `/lambda`, and `/fetch` subpath exports each provide a `load()` function for async access in CommonJS. The individual functions are not synchronously available via `require()`.
 
 ```javascript
 // Helpers


### PR DESCRIPTION
Fixes the nginx verification snippet (map instead of proxy_set_header inside if), the Koa example's strict-true contract, and the CJS subpath and API lists.