### PR TITLE
fix(middleware): call next() once when a downstream handler throws

### DIFF
--- a/lib/clientCertificateAuth.cjs
+++ b/lib/clientCertificateAuth.cjs
@@ -186,22 +186,28 @@ function clientCertificateAuth(callback, options = {}) {
             }
         }
 
+        let result;
+        let asynchronous;
         try {
-            const result = callback(cert, req);
-            if (isThenable(result)) {
-                Promise.resolve(result).then(doneAuthorizing).catch((rejection) => {
-                    const err = normalizeCallbackError(rejection);
-                    safeCallHook(onRejected, cert, req, errorMessage(err) || 'callback_threw');
-                    next(err);
-                });
-            } else {
-                doneAuthorizing(result);
-            }
+            result = callback(cert, req);
+            asynchronous = isThenable(result);
         } catch (thrown) {
             const err = normalizeCallbackError(thrown);
             safeCallHook(onRejected, cert, req, errorMessage(err) || 'callback_threw');
-            next(err);
+            return next(err);
         }
+
+        // The callback guard does not cover next(): a downstream throw is not a
+        // callback failure. The async path returns its promise, which rejects
+        // with a downstream throw for the caller to handle.
+        if (asynchronous) {
+            return Promise.resolve(result).then(doneAuthorizing, (rejection) => {
+                const err = normalizeCallbackError(rejection);
+                safeCallHook(onRejected, cert, req, errorMessage(err) || 'callback_threw');
+                next(err);
+            });
+        }
+        doneAuthorizing(result);
     };
 }
 

--- a/lib/clientCertificateAuth.d.cts
+++ b/lib/clientCertificateAuth.d.cts
@@ -116,7 +116,7 @@ export type Middleware = (
     req: ClientCertRequest,
     res: ClientCertResponse,
     next: (err?: Error | HttpError) => void
-) => void;
+) => void | Promise<void>;
 
 /**
  * Express/Connect middleware for client SSL certificate authentication.

--- a/lib/clientCertificateAuth.d.ts
+++ b/lib/clientCertificateAuth.d.ts
@@ -155,7 +155,7 @@ export type Middleware = (
     req: ClientCertRequest,
     res: ClientCertResponse,
     next: (err?: Error | HttpError) => void
-) => void;
+) => void | Promise<void>;
 
 /**
  * Express/Connect middleware for client SSL certificate authentication.

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -68,7 +68,7 @@ function normalizeCallbackError(err) {
 /**
  * @typedef {import('http').IncomingMessage & { secure?: boolean; socket: import('net').Socket & { authorized?: boolean; authorizationError?: Error | string; getPeerCertificate?: (detailed?: boolean) => import('tls').PeerCertificate | import('tls').DetailedPeerCertificate }; clientCertificate?: import('./parsers.js').ChainedPeerCertificate }} ClientCertRequest
  * @typedef {import('http').ServerResponse} ClientCertResponse
- * @typedef {(req: ClientCertRequest, res: ClientCertResponse, next: (err?: Error) => void) => void} Middleware
+ * @typedef {(req: ClientCertRequest, res: ClientCertResponse, next: (err?: Error) => void) => void | Promise<void>} Middleware
  */
 
 /**
@@ -238,21 +238,27 @@ export default function clientCertificateAuth(callback, options = {}) {
       }
     }
 
+    let callbackResult;
+    let asynchronous;
     try {
-      const callbackResult = callback(cert, req);
-      if (isThenable(callbackResult)) {
-        Promise.resolve(callbackResult).then(doneAuthorizing).catch((rejection) => {
-          const err = normalizeCallbackError(rejection);
-          safeCallHook(onRejected, cert, req, errorMessage(err) || 'callback_threw');
-          next(err);
-        });
-      } else {
-        doneAuthorizing(callbackResult);
-      }
+      callbackResult = callback(cert, req);
+      asynchronous = isThenable(callbackResult);
     } catch (thrown) {
       const err = normalizeCallbackError(thrown);
       safeCallHook(onRejected, cert, req, errorMessage(err) || 'callback_threw');
-      next(err);
+      return next(err);
     }
+
+    // The callback guard does not cover next(): a downstream throw is not a
+    // callback failure. The async path returns its promise, which rejects with
+    // a downstream throw for the caller to handle.
+    if (asynchronous) {
+      return Promise.resolve(callbackResult).then(doneAuthorizing, (rejection) => {
+        const err = normalizeCallbackError(rejection);
+        safeCallHook(onRejected, cert, req, errorMessage(err) || 'callback_threw');
+        next(err);
+      });
+    }
+    doneAuthorizing(callbackResult);
   };
 }

--- a/test/test-typescript-types.ts
+++ b/test/test-typescript-types.ts
@@ -3,7 +3,7 @@
  * This file is not executed, only type-checked by `npm run typecheck`.
  */
 import clientCertificateAuth from '../lib/clientCertificateAuth.js';
-import type { ClientCertRequest, HttpError, ClientCertificateAuthOptions, ValidationCallback } from '../lib/clientCertificateAuth.js';
+import type { ClientCertRequest, HttpError, ClientCertificateAuthOptions, Middleware, ValidationCallback } from '../lib/clientCertificateAuth.js';
 
 // Test 1: Error.status augmentation works on plain Error objects
 const plainError = new Error('test');
@@ -328,3 +328,8 @@ void _terminatingChain;
 void _chainInCallback;
 void readChainOffRequest;
 void _chainInHooks;
+
+// Test 23: the middleware returns the promise from an async callback, so
+// Express 5 can await it and surface a downstream throw.
+type Assert<T extends true> = T;
+type _MiddlewareMayReturnPromise = Assert<Promise<void> extends ReturnType<Middleware> ? true : false>;

--- a/test/test-unit-clientCertificateAuth.cjs
+++ b/test/test-unit-clientCertificateAuth.cjs
@@ -331,6 +331,26 @@ describe('clientCertificateAuth (CommonJS)', () => {
                 });
             });
 
+            it('should not call next() again when a downstream handler throws after sync authorization', () => {
+                const middleware = clientCertificateAuth(() => true);
+                let calls = 0;
+                assert.throws(() => middleware(mockGoodReq, mockRes, () => {
+                    calls++;
+                    throw new Error('downstream threw');
+                }), /downstream threw/);
+                assert.equal(calls, 1);
+            });
+
+            it('should not call next() again when a downstream handler throws after async authorization', async () => {
+                const middleware = clientCertificateAuth(async () => true);
+                let calls = 0;
+                await assert.rejects(() => middleware(mockGoodReq, mockRes, () => {
+                    calls++;
+                    throw new Error('downstream threw');
+                }), /downstream threw/);
+                assert.equal(calls, 1);
+            });
+
             it('should pass a frozen sync error to next() with status 401', done => {
                 const locked = Object.freeze(new Error('locked'));
                 const middleware = clientCertificateAuth(() => {

--- a/test/test-unit-clientCertificateAuth.js
+++ b/test/test-unit-clientCertificateAuth.js
@@ -336,6 +336,26 @@ describe('clientCertificateAuth', () => {
         });
       });
 
+      it('should not call next() again when a downstream handler throws after sync authorization', () => {
+        const middleware = clientCertificateAuth(() => true);
+        let calls = 0;
+        assert.throws(() => middleware(mockGoodReq, mockRes, () => {
+          calls++;
+          throw new Error('downstream threw');
+        }), /downstream threw/);
+        assert.equal(calls, 1);
+      });
+
+      it('should not call next() again when a downstream handler throws after async authorization', async () => {
+        const middleware = clientCertificateAuth(async () => true);
+        let calls = 0;
+        await assert.rejects(() => middleware(mockGoodReq, mockRes, () => {
+          calls++;
+          throw new Error('downstream threw');
+        }), /downstream threw/);
+        assert.equal(calls, 1);
+      });
+
       it('should pass a frozen sync error to next() with status 401', done => {
         const locked = Object.freeze(new Error('locked'));
         const middleware = clientCertificateAuth(() => {


### PR DESCRIPTION
A throw from next() no longer triggers a second next(err); the async path returns its promise. Stacked on #201.