### PR TITLE
fix(extractor): reject repeated certificate headers and enforce the RFC 9440 byte-sequence form

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ app.use(clientCertificateAuth(checkAuth, {
 | `url-pem-aws` | URL-encoded PEM (AWS variant, `+` as safe char) | AWS ALB |
 | `xfcc` | Envoy's structured `Key=Value;...` format | Envoy, Istio |
 | `base64-der` | Base64-encoded DER certificate | Cloudflare, Traefik, Azure App Service, HAProxy (`ssl_c_der,base64`) |
-| `rfc9440` | RFC 9440 format: `:base64-der:` | Cloudflare (RFC 9440 forwarding), Google Cloud LB |
+| `rfc9440` | RFC 9440 format: exactly `:base64-der:` | Cloudflare (RFC 9440 forwarding), Google Cloud LB |
 
 HAProxy's native certificate forwarding (`http-request set-header ... %[ssl_c_der,base64]`) is base64 DER, so pair it with `base64-der`. HAProxy has no built-in URL-encoded-PEM output; `url-pem` from HAProxy requires a custom Lua `url_enc` converter.
 
@@ -856,6 +856,7 @@ The E2E tests spin up real reverse proxies, generate fresh certificates, and ver
 
 - Set `rejectUnauthorized: false` on your HTTPS server to let this middleware provide helpful error messages, rather than dropping connections silently
 - **When using header-based auth**, ensure your proxy strips certificate headers from external requests
+- Repeated certificate or verification header lines are rejected (Node joins repeats with `, `, so the first value would otherwise win); chain headers are RFC 9440 lists and may repeat
 - Use `verifyHeader`/`verifyValue` as defense-in-depth when using header-based authentication
 
 ## Upgrading from 1.x

--- a/docs/guide/reverse-proxy.md
+++ b/docs/guide/reverse-proxy.md
@@ -125,7 +125,7 @@ The library supports five encoding formats covering all major reverse proxies:
 | `url-pem-aws` | URL-encoded PEM (AWS variant, `+` as safe char) | AWS ALB |
 | `xfcc` | Envoy's structured `Key=Value;...` format | Envoy, Istio |
 | `base64-der` | Base64-encoded DER certificate | Cloudflare, Traefik, Azure App Service, Caddy, HAProxy (`ssl_c_der,base64`) |
-| `rfc9440` | RFC 9440 format: `:base64-der:` | Cloudflare (RFC 9440 forwarding), Google Cloud LB |
+| `rfc9440` | RFC 9440 format: exactly `:base64-der:` | Cloudflare (RFC 9440 forwarding), Google Cloud LB |
 
 HAProxy's native certificate forwarding (`http-request set-header ... %[ssl_c_der,base64]`) is base64 DER, so pair it with `base64-der`. HAProxy has no built-in URL-encoded-PEM output; `url-pem` from HAProxy requires a custom Lua `url_enc` converter.
 
@@ -184,6 +184,8 @@ Configure your proxy to:
 3. **Never** trust certificate headers from untrusted sources
 
 Without these precautions, an attacker could forge certificate headers and bypass authentication entirely.
+
+Repeated header lines are rejected. Node joins repeated headers with `, `, and every encoding would otherwise read the first value, so a request whose certificate or verification header appears more than once in `req.rawHeaders` fails closed (`header_missing_or_malformed`, or `verification_header_mismatch` for the verification header). A proxy that appends a second header line instead of replacing the client's therefore cannot hand the client-supplied value to the middleware. A proxy that appends *within* one header line is a different matter: Envoy's `APPEND_FORWARD` keeps the client's XFCC element and adds its own after it, all on one line, so `rawHeaders` sees a single occurrence and the first element (the one `xfcc` reads) is whatever the client sent. Configure Envoy with `SANITIZE_SET` or `FORWARD_ONLY`, never `APPEND_FORWARD`, on any hop reachable from outside the mesh. Chain headers are RFC 9440 lists and may repeat; repeated chain lines are combined, so a proxy that appends instead of replacing would let a client contribute certificates to the chain. Verifying every link by signature against a CA you control is what makes a forwarded chain trustworthy; fields read straight from `issuerCertificate` are not. Requests without `rawHeaders` (Web `Request` objects, Lambda events, hand-built request objects) are not checked, because their headers arrive already joined; there a joined repeat is still rejected wherever the encoding forbids a comma: the exact `:base64:` form required by `rfc9440`, both URL-encoded PEM encodings, and `base64-der` under every preset but `traefik`, whose leaf header carries the chain. A `base64-der` value read through `traefik` or a hand-configured `certificateHeader`, and any `xfcc` value, use the comma grammatically and have no equivalent signal.
 
 ## Verification Header (Defense in Depth)
 

--- a/lib/extractor.d.ts
+++ b/lib/extractor.d.ts
@@ -35,6 +35,8 @@
  *   non-object `headers` field, one whose accessor throws, and one holding a
  *   property whose accessor throws are all treated as having no headers.
  * @param {Record<string, string | string[] | undefined>} [req.headers] - HTTP headers object
+ * @param {string[]} [req.rawHeaders] - Node's raw header list; a certificate or
+ *   verification header that appears more than once is rejected
  * @param {Object} [req.socket] - TLS socket with getPeerCertificate() method
  * @param {boolean} [req.socket.authorized] - Whether socket was authorized
  * @param {(detailed: boolean) => import('tls').PeerCertificate} [req.socket.getPeerCertificate] - Get peer certificate
@@ -59,6 +61,7 @@
  */
 export function extractClientCertificate(req: {
     headers?: Record<string, string | string[] | undefined>;
+    rawHeaders?: string[];
     socket?: {
         authorized?: boolean;
         getPeerCertificate?: (detailed: boolean) => import("tls").PeerCertificate;

--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -9,6 +9,26 @@ import { getCertificateFromHeaders, parseHeaderValue, PRESETS } from './parsers.
 const VALID_ENCODINGS = ['url-pem', 'url-pem-aws', 'xfcc', 'base64-der', 'rfc9440'];
 
 /**
+ * Count the occurrences of a header name in Node's rawHeaders list
+ * (alternating name/value entries, original casing).
+ * @param {unknown} rawHeaders
+ * @param {string} name - Lowercase header name
+ * @returns {number}
+ */
+function countRawHeader(rawHeaders, name) {
+  if (!Array.isArray(rawHeaders)) {
+    return 0;
+  }
+  let count = 0;
+  for (let i = 0; i < rawHeaders.length; i += 2) {
+    if (typeof rawHeaders[i] === 'string' && rawHeaders[i].toLowerCase() === name) {
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
  * Validate options shared by `extractClientCertificate` and the middleware
  * constructor. Throws on misconfiguration: an unknown preset or encoding, a
  * header-name option that is not a non-empty string, a flag that is not a
@@ -132,6 +152,8 @@ export function validateExtractorOptions(options = {}) {
  *   non-object `headers` field, one whose accessor throws, and one holding a
  *   property whose accessor throws are all treated as having no headers.
  * @param {Record<string, string | string[] | undefined>} [req.headers] - HTTP headers object
+ * @param {string[]} [req.rawHeaders] - Node's raw header list; a certificate or
+ *   verification header that appears more than once is rejected
  * @param {Object} [req.socket] - TLS socket with getPeerCertificate() method
  * @param {boolean} [req.socket.authorized] - Whether socket was authorized
  * @param {(detailed: boolean) => import('tls').PeerCertificate} [req.socket.getPeerCertificate] - Get peer certificate
@@ -177,7 +199,13 @@ export function extractClientCertificate(req, options = {}) {
     // rather than at whichever lookup reaches it.
     /** @type {Record<string, string | string[] | undefined>} */
     let headers = Object.create(null);
+    /** @type {unknown} */
+    let rawHeaders;
     try {
+      // Copied for the same reason as the headers below: countRawHeader walks
+      // it later, well outside this block.
+      const suppliedRaw = req?.rawHeaders;
+      rawHeaders = Array.isArray(suppliedRaw) ? Array.prototype.slice.call(suppliedRaw) : undefined;
       const supplied = req?.headers;
       if (supplied !== null && typeof supplied === 'object') {
         for (const name of Object.keys(supplied)) {
@@ -185,15 +213,25 @@ export function extractClientCertificate(req, options = {}) {
         }
       }
     } catch {
-      // Unreadable headers count as none; a partial read is discarded.
+      // Unreadable headers count as none, rawHeaders with them; a partial read
+      // is discarded.
       headers = Object.create(null);
+      rawHeaders = undefined;
     }
 
-    // Verify upstream proxy's certificate validation if configured
+    // Resolve: explicit certificateHeader/chainHeader > preset; explicit encoding > preset.
+    const preset = certificateSource ? PRESETS[certificateSource] : null;
+    const leafHeaderName = certificateHeader ? certificateHeader.toLowerCase() : preset?.header;
+    const chainHeaderName = (chainHeader ?? preset?.chainHeader)?.toLowerCase();
+    const chainEncoding = headerEncoding ?? preset?.encoding;
+
+    // Verify upstream proxy's certificate validation if configured. Node joins
+    // repeated header lines with ", ", so a repeated verification header is a mismatch.
     // Stryker disable next-line LogicalOperator: construction-time validation ensures both set or neither, single-side check is redundant but clearer
     if (verifyHeader && verifyValue) {
-      const verifyStatus = headers[verifyHeader.toLowerCase()];
-      if (Array.isArray(verifyStatus) || verifyStatus !== verifyValue) {
+      const verifyName = verifyHeader.toLowerCase();
+      const verifyStatus = headers[verifyName];
+      if (Array.isArray(verifyStatus) || verifyStatus !== verifyValue || countRawHeader(rawHeaders, verifyName) > 1) {
         return {
           success: false,
           certificate: null,
@@ -202,34 +240,35 @@ export function extractClientCertificate(req, options = {}) {
       }
     }
 
-    cert = getCertificateFromHeaders(headers, {
-      certificateSource,
-      certificateHeader,
-      headerEncoding,
-    });
+    // A repeated certificate header line is ambiguous: every encoding would read
+    // the first value. Treat it as malformed. Chain headers are RFC 9440 lists
+    // and may legitimately repeat; Node joins the lines with commas.
+    const repeated = countRawHeader(rawHeaders, /** @type {string} */ (leafHeaderName)) > 1;
+
+    if (!repeated) {
+      cert = getCertificateFromHeaders(headers, {
+        certificateSource,
+        certificateHeader,
+        headerEncoding,
+      });
+    }
 
     // Append chain from a separate chain header if configured.
-    // Resolve: explicit chainHeader > preset.chainHeader; explicit encoding > preset.encoding.
     // Split on commas per RFC 9440, parse each item, link via issuerCertificate.
-    if (cert) {
-      const preset = certificateSource ? PRESETS[certificateSource] : null;
-      const chainHeaderName = (chainHeader ?? preset?.chainHeader)?.toLowerCase();
-      const chainEncoding = headerEncoding ?? preset?.encoding;
-      if (chainHeaderName && chainEncoding) {
-        const chainHeaderValue = headers[chainHeaderName];
-        // Only a non-empty string is parseable; anything else leaves the leaf unchained.
-        if (typeof chainHeaderValue === 'string' && chainHeaderValue) {
-          const chainCerts = chainHeaderValue
-            .split(',')
-            .map(item => item.trim())
-            .filter(Boolean)
-            .map(item => parseHeaderValue(item, chainEncoding))
-            .filter(Boolean);
-          if (chainCerts.length > 0) {
-            cert.issuerCertificate = chainCerts[0];
-            for (let i = 0; i < chainCerts.length - 1; i++) {
-              chainCerts[i].issuerCertificate = chainCerts[i + 1];
-            }
+    if (cert && chainHeaderName && chainEncoding) {
+      const chainHeaderValue = headers[chainHeaderName];
+      // Only a non-empty string is parseable; anything else leaves the leaf unchained.
+      if (typeof chainHeaderValue === 'string' && chainHeaderValue) {
+        const chainCerts = chainHeaderValue
+          .split(',')
+          .map(item => item.trim())
+          .filter(Boolean)
+          .map(item => parseHeaderValue(item, chainEncoding, { chainInLeafHeader: false }))
+          .filter(Boolean);
+        if (chainCerts.length > 0) {
+          cert.issuerCertificate = chainCerts[0];
+          for (let i = 0; i < chainCerts.length - 1; i++) {
+            chainCerts[i].issuerCertificate = chainCerts[i + 1];
           }
         }
       }

--- a/lib/fetch.d.ts
+++ b/lib/fetch.d.ts
@@ -22,6 +22,12 @@ export interface RequestLike {
  *
  * @param request - A Web Request or any object with iterable headers. Missing or
  *   non-iterable headers, and entries that are not `[name, value]` tuples, are ignored.
+ *   A repeated certificate header is rejected where the iterable exposes it. A Web
+ *   `Headers` joins repeated lines into one value before this sees them: `url-pem`,
+ *   `url-pem-aws`, `rfc9440`, and `base64-der` under every preset but `traefik` reject
+ *   that joined form. `xfcc`, and `base64-der` read through `traefik` or a
+ *   hand-configured `certificateHeader`, use the comma grammatically and cannot tell it
+ *   apart, so there the origin must be reachable only through the proxy.
  * @param options - Same options as `extractClientCertificate`. Header options only.
  */
 export declare function extractClientCertificateFromRequest(

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -21,6 +21,12 @@ import { extractClientCertificate, validateExtractorOptions } from './extractor.
  *
  * @param {{ headers?: Iterable<[string, string]> }} request - A Web Request or any object whose `headers` iterates `[name, value]` pairs.
  *   Missing or non-iterable headers, and entries that are not `[name, value]` tuples, are ignored.
+ *   A repeated certificate header is rejected where the iterable exposes it. A Web `Headers`
+ *   joins repeated lines into one value before this sees them: `url-pem`, `url-pem-aws`,
+ *   `rfc9440`, and `base64-der` under every preset but `traefik` reject that joined form.
+ *   `xfcc`, and `base64-der` read through `traefik` or a hand-configured
+ *   `certificateHeader`, use the comma grammatically and cannot tell it apart, so there the
+ *   origin must be reachable only through the proxy.
  * @param {ExtractorOptions} [options={}] - Same options as `extractClientCertificate`. Header-extraction options only; socket options are ignored.
  * @returns {ExtractionResult}
  *
@@ -54,6 +60,8 @@ export function extractClientCertificateFromRequest(request, options = {}) {
   // Web Headers normalizes to lowercase, but Map and other iterables
   // preserve casing. Normalize here for the core extractor's lowercase lookup.
   let headers = Object.create(null);
+  /** @type {string[]} */
+  let rawHeaders = [];
   try {
     const supplied = /** @type {any} */ (request?.headers);
     if (typeof supplied?.[Symbol.iterator] === 'function') {
@@ -67,15 +75,19 @@ export function extractClientCertificateFromRequest(request, options = {}) {
         if (typeof name !== 'string' || typeof value !== 'string') {
           continue;
         }
+        // Every entry is recorded, so a repeated certificate header reaches the
+        // extractor's duplicate check.
+        rawHeaders.push(name, value);
         headers[name.toLowerCase()] = value;
       }
     }
   } catch {
     // A throwing iterator or accessor leaves a partial read. Discard it.
     headers = Object.create(null);
+    rawHeaders = [];
   }
 
   const { fallbackToSocket: _ignored, ...rest } = options;
 
-  return extractClientCertificate({ headers }, rest);
+  return extractClientCertificate({ headers, rawHeaders }, rest);
 }

--- a/lib/parsers.d.ts
+++ b/lib/parsers.d.ts
@@ -45,6 +45,12 @@ export interface PresetConfig {
     chainHeader?: string;
     /** Encoding format used by this proxy */
     encoding: HeaderEncoding;
+    /**
+     * Set when this proxy forwards the whole chain in the leaf header rather
+     * than the leaf alone. Where it is unset, a comma in the value is read as
+     * a joined repeat and rejected.
+     */
+    chainInLeafHeader?: boolean;
 }
 
 /**
@@ -87,7 +93,10 @@ export declare function parseXfcc(headerValue: string): ChainedPeerCertificate |
  * Also handles Traefik's comma-separated cert chains.
  * @see https://developers.cloudflare.com/api-shield/security/mtls/configure/
  */
-export declare function parseBase64Der(headerValue: string): ChainedPeerCertificate | null;
+export declare function parseBase64Der(
+    headerValue: string,
+    options?: { chainInLeafHeader?: boolean }
+): ChainedPeerCertificate | null;
 
 /**
  * Parse RFC 9440 format certificate (used by Google Cloud Load Balancer).
@@ -110,7 +119,8 @@ export declare function derToCertificate(der: Buffer): PeerCertificate;
  */
 export declare function parseHeaderValue(
     headerValue: string,
-    encoding: HeaderEncoding
+    encoding: HeaderEncoding,
+    options?: { chainInLeafHeader?: boolean }
 ): ChainedPeerCertificate | null;
 
 /**

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -89,6 +89,7 @@ export const PRESETS = {
     'traefik': {
         header: 'x-forwarded-tls-client-cert',
         encoding: 'base64-der',
+        chainInLeafHeader: true,
     },
 };
 
@@ -96,6 +97,7 @@ export const PRESETS = {
  * Parse URL-encoded PEM certificate (nginx, HAProxy format).
  * Uses standard URL encoding via $ssl_client_escaped_cert or similar.
  * Concatenated PEM blocks are split and linked via issuerCertificate.
+ * A value carrying a literal comma is rejected as a joined repeat.
  * 
  * @see https://nginx.org/en/docs/http/ngx_http_ssl_module.html#var_ssl_client_escaped_cert
  * @param {string} headerValue - URL-encoded PEM certificate
@@ -104,6 +106,12 @@ export const PRESETS = {
 export function parseUrlPem(headerValue) {
     // Stryker disable next-line BlockStatement,ConditionalExpression: falsy input falls through to try-catch → same null return
     if (!headerValue) {
+        return null;
+    }
+
+    // A URL-encoded PEM never contains a literal comma, so one marks a value
+    // joined from repeated header lines rather than a single certificate.
+    if (headerValue.includes(',')) {
         return null;
     }
 
@@ -202,6 +210,7 @@ function chainFromMultiBlockPem(pem) {
  * AWS ALB uses +, =, / as safe characters (not encoded), but decodeURIComponent
  * interprets + as space, so we must escape it first. AWS sends the full chain
  * as concatenated PEM blocks, which we split and link via issuerCertificate.
+ * A value carrying a literal comma is rejected as a joined repeat.
  *
  * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/mutual-authentication.html
  * @param {string} headerValue - AWS ALB URL-encoded PEM certificate
@@ -210,6 +219,12 @@ function chainFromMultiBlockPem(pem) {
 export function parseUrlPemAws(headerValue) {
     // Stryker disable next-line BlockStatement,ConditionalExpression: falsy input falls through to try-catch → same null return
     if (!headerValue) {
+        return null;
+    }
+
+    // ALB percent-encodes the comma, so a literal one marks a value joined from
+    // repeated header lines rather than a single certificate chain.
+    if (headerValue.includes(',')) {
         return null;
     }
 
@@ -386,11 +401,20 @@ export function parseXfcc(headerValue) {
  * 
  * @see https://developers.cloudflare.com/api-shield/security/mtls/configure/
  * @param {string} headerValue - Base64-encoded DER certificate(s)
+ * @param {{ chainInLeafHeader?: boolean }} [options] - `chainInLeafHeader: false`
+ *   rejects a comma instead of reading the value as a chain, for a source that
+ *   forwards the leaf alone.
  * @returns {ChainedPeerCertificate | null} Parsed certificate or null on failure
  */
-export function parseBase64Der(headerValue) {
+export function parseBase64Der(headerValue, { chainInLeafHeader = true } = {}) {
     // Stryker disable next-line BlockStatement,ConditionalExpression: falsy input falls through to try-catch → same null return
     if (!headerValue) {
+        return null;
+    }
+
+    // A source that forwards the leaf alone never sends a comma, so one marks a
+    // value joined from repeated header lines rather than a certificate chain.
+    if (!chainInLeafHeader && headerValue.includes(',')) {
         return null;
     }
 
@@ -426,30 +450,32 @@ export function parseBase64Der(headerValue) {
 }
 
 /**
- * Parse RFC 9440 format certificate (used by Google Cloud Load Balancer).
- * Format: :base64-encoded-der: (colon-delimited byte sequence).
- * 
+ * Parse an RFC 9440 Client-Cert value: an RFC 8941 Byte Sequence, i.e. base64
+ * DER between colons and nothing else. Cloudflare's RFC 9440 forwarding and
+ * Google Cloud's {client_cert_leaf} variable both produce this form. Anything
+ * outside the colons (parameters, joined repeats, bare base64) is rejected.
+ *
  * @see https://datatracker.ietf.org/doc/html/rfc9440#section-2.1
  * @param {string} headerValue - RFC 9440 formatted certificate
  * @returns {PeerCertificate | null} Parsed certificate or null on failure
  */
 export function parseRfc9440(headerValue) {
-    // Stryker disable next-line BlockStatement,ConditionalExpression: falsy input falls through to try-catch → same null return
-    if (!headerValue) {
+    const match = /^:([A-Za-z0-9+/]*={0,2}):$/.exec(headerValue);
+    if (!match) {
         return null;
     }
 
+    const base64 = match[1];
+    // Buffer.from ignores anything it cannot decode, so a value carrying trailing
+    // junk would otherwise parse as the certificate in front of it. Requiring a
+    // round trip to the same text rejects it; derToCertificate rejects trailing
+    // bytes that survive the round trip because they decode cleanly.
     try {
-        // Strip colon delimiters
-        let base64 = headerValue;
-        // Stryker disable next-line BlockStatement,ConditionalExpression,StringLiteral,LogicalOperator,MethodExpression: colon-stripping is defensive; all valid RFC 9440 inputs use :base64: format, so base64 decoder ignores colons either way
-        if (base64.startsWith(':') && base64.endsWith(':')) {
-            // Stryker disable next-line MethodExpression: no-oping the assignment is equivalent — base64 decoder ignores colons
-            base64 = base64.slice(1, -1);
+        const der = Buffer.from(base64, 'base64');
+        if (der.toString('base64') !== base64) {
+            return null;
         }
-
-        const derBuffer = Buffer.from(base64, 'base64');
-        return derToCertificate(derBuffer);
+        return derToCertificate(der);
     } catch {
         return null;
     }
@@ -479,6 +505,11 @@ export function pemToCertificate(pem) {
 export function derToCertificate(der) {
     // X509Certificate can accept DER directly
     const x509 = new X509Certificate(der);
+    // It parses the certificate at the front and ignores whatever follows, so
+    // a value carrying extra bytes would otherwise read as the leading one.
+    if (x509.raw.length !== der.length) {
+        throw new Error('client-certificate-auth: trailing data after DER certificate');
+    }
     return x509.toLegacyObject();
 }
 
@@ -487,9 +518,10 @@ export function derToCertificate(der) {
  * 
  * @param {string} headerValue - Raw header value
  * @param {'url-pem' | 'url-pem-aws' | 'xfcc' | 'base64-der' | 'rfc9440'} encoding - Encoding format
+ * @param {{ chainInLeafHeader?: boolean }} [options] - Forwarded to the encoding's parser.
  * @returns {ChainedPeerCertificate | null} Parsed certificate or null on failure
  */
-export function parseHeaderValue(headerValue, encoding) {
+export function parseHeaderValue(headerValue, encoding, options = {}) {
     // Only strings are parseable; a header name like 'constructor' resolves
     // to a function on plain-object header maps.
     if (typeof headerValue !== 'string') {
@@ -504,7 +536,7 @@ export function parseHeaderValue(headerValue, encoding) {
         case 'xfcc':
             return parseXfcc(headerValue);
         case 'base64-der':
-            return parseBase64Der(headerValue);
+            return parseBase64Der(headerValue, options);
         case 'rfc9440':
             return parseRfc9440(headerValue);
         default:
@@ -525,6 +557,9 @@ export function parseHeaderValue(headerValue, encoding) {
 export function getCertificateFromHeaders(headers, config) {
     let headerName;
     let encoding;
+    // A hand-configured header keeps the permissive default; only a preset
+    // knows whether its proxy forwards a chain in the leaf header.
+    let chainInLeafHeader = true;
 
     if (config.certificateSource) {
         const preset = PRESETS[config.certificateSource];
@@ -533,6 +568,7 @@ export function getCertificateFromHeaders(headers, config) {
         }
         headerName = preset.header;
         encoding = preset.encoding;
+        chainInLeafHeader = preset.chainInLeafHeader === true;
     }
 
     // Custom header overrides preset header name
@@ -565,5 +601,5 @@ export function getCertificateFromHeaders(headers, config) {
         return null;
     }
 
-    return parseHeaderValue(headerValue, encoding);
+    return parseHeaderValue(headerValue, encoding, { chainInLeafHeader });
 }

--- a/test/test-unit-extractor.js
+++ b/test/test-unit-extractor.js
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict';
+import http from 'node:http';
+import net from 'node:net';
 import { extractClientCertificate, validateExtractorOptions } from '../lib/extractor.js';
 import { pemToDer } from './test-helpers.js';
 
@@ -290,6 +292,19 @@ describe('extractClientCertificate', () => {
       ['headers whose keys cannot be enumerated', {
         headers: new Proxy({}, { ownKeys() { throw new Error('ownKeys threw'); } }),
       }],
+      ['a throwing rawHeaders accessor', {
+        headers: { 'x-amzn-mtls-clientcert': 'irrelevant' },
+        get rawHeaders() { throw new Error('rawHeaders trap'); },
+      }],
+      ['rawHeaders that throw while being walked', {
+        headers: { 'x-amzn-mtls-clientcert': 'irrelevant' },
+        rawHeaders: new Proxy(['x-amzn-mtls-clientcert', 'v'], {
+          get(target, prop) {
+            if (prop === 'length') { throw new Error('rawHeaders trap'); }
+            return Reflect.get(target, prop);
+          },
+        }),
+      }],
     ];
 
     for (const [label, req] of cases) {
@@ -361,6 +376,186 @@ describe('extractClientCertificate', () => {
 
       assert.strictEqual(result.success, false);
       assert.strictEqual(result.reason, 'socket_not_authorized');
+    });
+  });
+
+  describe('repeated header lines', () => {
+    const encoded = () => encodeURIComponent(testPem);
+
+    // traefik reads a comma as its own chain separator, so the joined value
+    // parses and only the rawHeaders count can reject it.
+    const joinedDer = () => `${pemToDer(testPem).toString('base64')},${pemToDer(testPem).toString('base64')}`;
+
+    it('should reject a certificate header that appears more than once in rawHeaders', () => {
+      const req = {
+        headers: { 'x-forwarded-tls-client-cert': joinedDer() },
+        rawHeaders: [
+          'X-Forwarded-Tls-Client-Cert', pemToDer(testPem).toString('base64'),
+          'Host', 'example.com',
+          'x-forwarded-tls-client-cert', pemToDer(testPem).toString('base64'),
+        ],
+        socket: { authorized: false },
+      };
+
+      const result = extractClientCertificate(req, { certificateSource: 'traefik' });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.certificate, null);
+      assert.strictEqual(result.reason, 'header_missing_or_malformed');
+    });
+
+    it('should accept the same traefik chain when the header appears once', () => {
+      const req = {
+        headers: { 'x-forwarded-tls-client-cert': joinedDer() },
+        rawHeaders: ['X-Forwarded-Tls-Client-Cert', joinedDer()],
+        socket: { authorized: false },
+      };
+
+      const result = extractClientCertificate(req, { certificateSource: 'traefik' });
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.certificate.subject.CN, 'client.example.com');
+    });
+
+    it('should reject a url-pem certificate header repeated in rawHeaders', () => {
+      const req = {
+        headers: { 'x-amzn-mtls-clientcert': `${encoded()}, ${encoded()}` },
+        rawHeaders: ['X-Amzn-Mtls-Clientcert', encoded(), 'Host', 'example.com', 'x-amzn-mtls-clientcert', encoded()],
+        socket: { authorized: false },
+      };
+
+      const result = extractClientCertificate(req, { certificateSource: 'aws-alb' });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.certificate, null);
+      assert.strictEqual(result.reason, 'header_missing_or_malformed');
+    });
+
+    it('should accept a certificate header that appears exactly once', () => {
+      const req = {
+        headers: { 'x-amzn-mtls-clientcert': encoded(), 'x-forwarded-for': '10.0.0.1, 10.0.0.2' },
+        rawHeaders: ['X-Forwarded-For', '10.0.0.1', 'X-Amzn-Mtls-Clientcert', encoded(), 'X-Forwarded-For', '10.0.0.2'],
+        socket: { authorized: false },
+      };
+
+      const result = extractClientCertificate(req, { certificateSource: 'aws-alb' });
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.certificate.subject.CN, 'client.example.com');
+    });
+
+    it('should fall back to the socket when a repeated header is rejected and fallbackToSocket is true', () => {
+      const mockCert = getMockPeerCertificate();
+      const req = {
+        headers: { 'x-forwarded-tls-client-cert': joinedDer() },
+        rawHeaders: [
+          'X-Forwarded-Tls-Client-Cert', pemToDer(testPem).toString('base64'),
+          'X-Forwarded-Tls-Client-Cert', pemToDer(testPem).toString('base64'),
+        ],
+        socket: { authorized: true, getPeerCertificate: () => mockCert },
+      };
+
+      const result = extractClientCertificate(req, { certificateSource: 'traefik', fallbackToSocket: true });
+
+      assert.strictEqual(result.success, true);
+      assert.deepStrictEqual(result.certificate, mockCert);
+    });
+
+    it('should read the first XFCC element, which an appending Envoy leaves client-controlled', () => {
+      // Envoy APPEND_FORWARD adds its element after the client's, on one header
+      // line, so the repeat check sees a single occurrence. Documented in
+      // reverse-proxy.md as a configuration the library cannot compensate for.
+      const value = `Hash=a;Cert=${encoded()},By=spiffe://mesh;Cert=${encoded()}`;
+      const req = {
+        headers: { 'x-forwarded-client-cert': value },
+        rawHeaders: ['X-Forwarded-Client-Cert', value],
+        socket: { authorized: false },
+      };
+
+      const result = extractClientCertificate(req, { certificateSource: 'envoy' });
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.certificate.subject.CN, 'client.example.com');
+    });
+
+    it('should reject a repeated verification header as verification_header_mismatch', () => {
+      const req = {
+        headers: { 'x-ssl-client-cert': encoded(), 'x-ssl-client-verify': 'SUCCESS' },
+        rawHeaders: ['X-SSL-Client-Verify', 'SUCCESS', 'X-SSL-Client-Cert', encoded(), 'X-SSL-Client-Verify', 'FAILED'],
+        socket: { authorized: false },
+      };
+
+      const result = extractClientCertificate(req, {
+        certificateHeader: 'X-SSL-Client-Cert',
+        headerEncoding: 'url-pem',
+        verifyHeader: 'X-SSL-Client-Verify',
+        verifyValue: 'SUCCESS',
+      });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'verification_header_mismatch');
+    });
+
+    it('should combine repeated chain header lines as an RFC 9440 list', () => {
+      const leaf = encodeAsRfc9440(pemToDer(testPem));
+      const req = {
+        headers: { 'client-cert': leaf, 'client-cert-chain': `${leaf}, ${leaf}` },
+        rawHeaders: ['Client-Cert', leaf, 'Client-Cert-Chain', leaf, 'Client-Cert-Chain', leaf],
+        socket: { authorized: false },
+      };
+
+      const result = extractClientCertificate(req, { certificateSource: 'cloudflare-rfc9440', includeChain: true });
+
+      assert.strictEqual(result.success, true);
+      assert.ok(result.certificate.issuerCertificate);
+      assert.ok(result.certificate.issuerCertificate.issuerCertificate);
+      assert.strictEqual(result.certificate.issuerCertificate.issuerCertificate.issuerCertificate, undefined);
+    });
+
+    it('should ignore rawHeaders that are not an array or contain non-string names', () => {
+      for (const rawHeaders of ['X-Amzn-Mtls-Clientcert', [42, encoded(), 'X-Amzn-Mtls-Clientcert', encoded()]]) {
+        const req = {
+          headers: { 'x-amzn-mtls-clientcert': encoded() },
+          rawHeaders,
+          socket: { authorized: false },
+        };
+
+        const result = extractClientCertificate(req, { certificateSource: 'aws-alb' });
+
+        assert.strictEqual(result.success, true);
+      }
+    });
+
+    it('should reject repeated header lines as parsed by Node http', async () => {
+      const seen = [];
+      const server = http.createServer((req, res) => {
+        seen.push(extractClientCertificate(req, { certificateSource: 'aws-alb' }));
+        res.end();
+      });
+      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+      const { port } = server.address();
+
+      const send = (lines) => new Promise((resolve, reject) => {
+        const socket = net.connect(port, '127.0.0.1', () => {
+          socket.end(['GET / HTTP/1.1', 'Host: example.com', ...lines, 'Connection: close', '', ''].join('\r\n'));
+        });
+        socket.resume();
+        socket.on('error', reject);
+        socket.on('close', resolve);
+      });
+
+      try {
+        await send([`X-Amzn-Mtls-Clientcert: ${encoded()}`, `X-Amzn-Mtls-Clientcert: ${encoded()}`]);
+        await send([`X-Amzn-Mtls-Clientcert: ${encoded()}`]);
+      } finally {
+        await new Promise(resolve => server.close(resolve));
+      }
+
+      assert.strictEqual(seen.length, 2);
+      assert.strictEqual(seen[0].success, false);
+      assert.strictEqual(seen[0].reason, 'header_missing_or_malformed');
+      assert.strictEqual(seen[1].success, true);
+      assert.strictEqual(seen[1].certificate.subject.CN, 'client.example.com');
     });
   });
 

--- a/test/test-unit-fetch.js
+++ b/test/test-unit-fetch.js
@@ -357,6 +357,119 @@ describe('extractClientCertificateFromRequest', () => {
     });
   });
 
+  describe('repeated certificate headers', () => {
+    let attackerPem;
+
+    beforeAll(async () => {
+      const attacker = await generateClientCertificate('attacker.example.com');
+      attackerPem = attacker.cert;
+    });
+
+    it('should reject duplicates a Web Headers joined into one value', () => {
+      const headers = new Headers();
+      headers.append('X-Amzn-Mtls-Clientcert', encodeURIComponent(attackerPem));
+      headers.append('X-Amzn-Mtls-Clientcert', encodeURIComponent(testPem));
+      const request = new Request('https://example.com/api', { headers });
+
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'aws-alb',
+      });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'header_missing_or_malformed');
+    });
+
+    it('should reject duplicates an iterable exposes as separate entries', () => {
+      const headers = [
+        ['x-arr-clientcert', pemToDer(attackerPem).toString('base64')],
+        ['x-arr-clientcert', testDer.toString('base64')],
+      ];
+
+      const result = extractClientCertificateFromRequest({ headers }, {
+        certificateSource: 'azure-app-service',
+      });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'header_missing_or_malformed');
+    });
+
+    it('should reject a duplicated verification header', () => {
+      const headers = [
+        ['client-cert', encodeAsRfc9440(testDer)],
+        ['x-ssl-verify', 'SUCCESS'],
+        ['x-ssl-verify', 'SUCCESS'],
+      ];
+
+      const result = extractClientCertificateFromRequest({ headers }, {
+        certificateSource: 'cloudflare-rfc9440',
+        verifyHeader: 'X-SSL-Verify',
+        verifyValue: 'SUCCESS',
+      });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'verification_header_mismatch');
+    });
+
+    it('should reject a base64-der duplicate a Web Headers joined into one value', () => {
+      const headers = new Headers();
+      headers.append('X-ARR-ClientCert', pemToDer(attackerPem).toString('base64'));
+      headers.append('X-ARR-ClientCert', testDer.toString('base64'));
+      const request = new Request('https://example.com/api', { headers });
+
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'azure-app-service',
+      });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'header_missing_or_malformed');
+    });
+
+    it('should reject a Cloudflare base64-der duplicate joined into one value', () => {
+      const headers = new Headers();
+      headers.append('Cf-Client-Cert-Der-Base64', pemToDer(attackerPem).toString('base64'));
+      headers.append('Cf-Client-Cert-Der-Base64', testDer.toString('base64'));
+      const request = new Request('https://example.com/api', { headers });
+
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'cloudflare',
+      });
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.reason, 'header_missing_or_malformed');
+    });
+
+    it('should still read a Traefik chain, which the leaf header carries', () => {
+      const headers = new Headers();
+      headers.set(
+        'X-Forwarded-Tls-Client-Cert',
+        [testDer.toString('base64'), pemToDer(attackerPem).toString('base64')].join(',')
+      );
+      const request = new Request('https://example.com/api', { headers });
+
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'traefik',
+        includeChain: true,
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
+      assert.strictEqual(result.certificate.issuerCertificate.subject.CN, 'attacker.example.com');
+    });
+
+    it('should still accept a header that appears once', () => {
+      const headers = new Headers();
+      headers.append('X-Amzn-Mtls-Clientcert', encodeURIComponent(testPem));
+      const request = new Request('https://example.com/api', { headers });
+
+      const result = extractClientCertificateFromRequest(request, {
+        certificateSource: 'aws-alb',
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.certificate.subject.CN, 'fetch.example.com');
+    });
+  });
+
   describe('header-only behavior', () => {
     it('should never access a socket field even if one is present on the request', () => {
       const headers = new Headers();

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -204,6 +204,14 @@ describe('parsers module', () => {
             assert.ok(cert);
             assert.equal(cert.subject.CN, 'Test Parser Client');
         });
+
+        it('should reject a value joined from repeated header lines', () => {
+            // A URL-encoded PEM has no literal comma, so one marks the ", " a
+            // Web Headers or Node inserts when it joins repeated lines.
+            const encoded = encodeAsNginx(testPem);
+
+            assert.equal(parseUrlPem(`${encoded}, ${encoded}`), null);
+        });
     });
 
     describe('parseUrlPemAws (AWS ALB format)', () => {
@@ -277,6 +285,14 @@ describe('parsers module', () => {
 
             assert.ok(cert);
             assert.equal(cert.subject.CN, 'Test Parser Client');
+        });
+
+        it('should reject a value joined from repeated header lines', () => {
+            // ALB percent-encodes the comma, so a literal one marks the ", " a
+            // Web Headers or Node inserts when it joins repeated lines.
+            const encoded = encodeAsAwsAlb(testPem);
+
+            assert.equal(parseUrlPemAws(`${encoded}, ${encoded}`), null);
         });
     });
 
@@ -673,6 +689,25 @@ describe('parsers module', () => {
             assert.equal(parseBase64Der(`${invalidCert},${invalidCert}`), null);
         });
 
+        it('should reject a certificate carrying trailing bytes', () => {
+            const withTrailing = Buffer.concat([testDer, Buffer.alloc(3)]).toString('base64');
+            assert.equal(parseBase64Der(withTrailing), null);
+        });
+
+        it('should reject a value joined from repeated header lines when the leaf header carries no chain', () => {
+            const cert1 = encodeAsCloudflare(testDer);
+            const cert2 = encodeAsCloudflare(testDer);
+
+            assert.equal(parseBase64Der(`${cert1},${cert2}`, { chainInLeafHeader: false }), null);
+            assert.ok(parseBase64Der(`${cert1},${cert2}`, { chainInLeafHeader: true }));
+        });
+
+        it('should accept a single certificate when the leaf header carries no chain', () => {
+            const cert = parseBase64Der(encodeAsCloudflare(testDer), { chainInLeafHeader: false });
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+        });
+
         it('should link cert chain via issuerCertificate for multiple valid certs', () => {
             // Create two different encodings of the same cert (simulating a chain)
             const cert1 = encodeAsCloudflare(testDer);
@@ -750,13 +785,38 @@ describe('parsers module', () => {
             assert.equal(cert.subject.CN, 'Test Parser Client');
         });
 
-        it('should handle input without colon delimiters', () => {
-            // Some implementations might strip the colons
-            const encoded = testDer.toString('base64');
-            const cert = parseRfc9440(encoded);
+        it('should reject input without colon delimiters', () => {
+            assert.equal(parseRfc9440(testDer.toString('base64')), null);
+            assert.equal(parseRfc9440(':' + testDer.toString('base64')), null);
+            assert.equal(parseRfc9440(testDer.toString('base64') + ':'), null);
+        });
 
-            assert.ok(cert);
-            assert.equal(cert.subject.CN, 'Test Parser Client');
+        it('should reject anything outside the byte sequence', () => {
+            const encoded = encodeAsRfc9440(testDer);
+            assert.equal(parseRfc9440(`${encoded};p=x`), null);
+            assert.equal(parseRfc9440(` ${encoded}`), null);
+            assert.equal(parseRfc9440(`${encoded}, ${encoded}`), null);
+            assert.equal(parseRfc9440(':not base64!:'), null);
+        });
+
+        it('should reject base64 carrying trailing data', () => {
+            const base64 = testDer.toString('base64');
+            // Buffer.from skips what it cannot decode, so anything after the
+            // certificate would otherwise parse as the certificate alone.
+            assert.equal(parseRfc9440(`:${base64}junk:`), null);
+            assert.equal(parseRfc9440(`:${base64}==junk:`), null);
+            assert.equal(parseRfc9440(`:${base64}${base64}:`), null);
+            assert.equal(parseRfc9440(`:${base64}A:`), null);
+            // Not a whole number of quartets, so it cannot round trip.
+            assert.equal(parseRfc9440(`:${base64.slice(0, -1)}:`), null);
+            assert.equal(parseRfc9440(':QUJDRQ:'), null);
+            // Non-zero bits under the padding: decodes, but not to this text.
+            assert.equal(parseRfc9440(':QR==:'), null);
+            // Trailing bytes that survive the round trip because the appended
+            // text is itself valid base64 of a whole number of bytes.
+            const padded = Buffer.concat([testDer, Buffer.alloc(3)]).toString('base64');
+            assert.equal(parseRfc9440(`:${padded}:`), null);
+            assert.equal(parseRfc9440('::'), null);
         });
 
         it('should return null for empty input', () => {


### PR DESCRIPTION
Repeated certificate or verification header lines (seen in req.rawHeaders) fail closed, repeated chain header lines are combined, and parseRfc9440 accepts only the RFC 8941 byte-sequence form. Stacked on #202.