### PR TITLE
fix(parsers): cap certificates per header value at MAX_CHAIN_CERTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ app.use(clientCertificateAuth((cert) => {
 
 When `includeChain: true`, the certificate object includes `issuerCertificate` linking to the issuer's certificate (and so on up the chain). This works consistently for both socket-based and header-based extraction, except on Node.js 26.8.0 and later, where a Node.js regression ([nodejs/node#65579](https://github.com/nodejs/node/issues/65579)) leaves `issuerCertificate` unset on the socket path; header-based extraction is unaffected. See [Troubleshooting](docs/guide/troubleshooting.md#certificate-chain-missing-on-nodejs-2680-and-later).
 
-For header-based extraction the first certificate in the header is the leaf. If it is empty or unparseable the header is rejected with `header_missing_or_malformed` rather than promoting the next certificate into the leaf position. See [Reverse Proxy Setup](https://tgies.github.io/client-certificate-auth/guide/reverse-proxy#chains-in-a-single-header) for the per-encoding details.
+For header-based extraction the first certificate in the header is the leaf. If it is empty or unparseable the header is rejected with `header_missing_or_malformed` rather than promoting the next certificate into the leaf position. A header value carries at most 10 certificates, leaf and chain header combined. See [Reverse Proxy Setup](https://tgies.github.io/client-certificate-auth/guide/reverse-proxy#chains-in-a-single-header) for the per-encoding details.
 
 ### User Login
 

--- a/docs/guide/reverse-proxy.md
+++ b/docs/guide/reverse-proxy.md
@@ -135,11 +135,13 @@ HAProxy's native certificate forwarding (`http-request set-header ... %[ssl_c_de
 
 The leaf entry has to parse on its own. If it is empty, unparseable, or preceded by anything other than whitespace, the whole header is rejected and extraction fails with `header_missing_or_malformed`. A leaf damaged in transit therefore produces a 401 rather than authenticating the request as the next certificate in the header. Entries after the leaf are dropped individually when they fail to parse, and the chain links past them.
 
+A header value carries at most 10 certificates (`MAX_CHAIN_CERTS`, exported from `client-certificate-auth/parsers`). Longer inputs are rejected before any certificate is parsed.
+
 ## Chain Header
 
 Some proxies forward the leaf certificate and the certificate chain in two separate headers. RFC 9440 is the canonical example: the leaf goes in `Client-Cert` and the chain in `Client-Cert-Chain` (a comma-separated structured-field list of `:base64:` items, leaf-nearest first).
 
-The `chainHeader` option pairs a chain header with the configured leaf header. The chain header value is split on commas, each item is parsed with the same `headerEncoding`, and the resulting certificates are linked via `issuerCertificate` after the leaf. Set `includeChain: true` to keep the chain on the request object; otherwise the chain is parsed and dropped (matching the existing single-header chain stripping behavior).
+The `chainHeader` option pairs a chain header with the configured leaf header. The chain header value is split on commas, each item is parsed with the same `headerEncoding`, and the resulting certificates are linked via `issuerCertificate` after the leaf. Set `includeChain: true` to keep the chain on the request object; otherwise the chain is parsed and dropped (matching the existing single-header chain stripping behavior). The leaf header and chain header together carry at most `MAX_CHAIN_CERTS` certificates; a longer chain header rejects the request with `header_missing_or_malformed`, discarding the leaf with it (with `fallbackToSocket: true` the socket certificate is used instead).
 
 ```javascript
 // Cloudflare RFC 9440 (chain header is configured automatically by the preset)

--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -4,9 +4,23 @@
  * @license MIT
  */
 
-import { getCertificateFromHeaders, parseHeaderValue, PRESETS } from './parsers.js';
+import { getCertificateFromHeaders, parseHeaderValue, MAX_CHAIN_CERTS, PRESETS } from './parsers.js';
 
 const VALID_ENCODINGS = ['url-pem', 'url-pem-aws', 'xfcc', 'base64-der', 'rfc9440'];
+
+/**
+ * Count a certificate and the issuerCertificate chain linked below it. The
+ * chain is always a finite list built during parsing.
+ * @param {unknown} cert
+ * @returns {number}
+ */
+function countChain(cert) {
+  let count = 0;
+  for (let c = cert; c; c = /** @type {any} */ (c).issuerCertificate) {
+    count++;
+  }
+  return count;
+}
 
 /**
  * Count the occurrences of a header name in Node's rawHeaders list
@@ -129,8 +143,9 @@ export function validateExtractorOptions(options = {}) {
  *   client identity.
  * @property {string} [chainHeader] - Optional second header carrying the certificate chain
  *   alongside the leaf. Split on commas per RFC 9440, each item parsed with the same
- *   `headerEncoding`, results linked via `issuerCertificate`. For non-RFC-9440 encodings
- *   the comma split may not match the encoding's list convention.
+ *   `headerEncoding`, results linked via `issuerCertificate`. Leaf and chain together may
+ *   not exceed MAX_CHAIN_CERTS certificates; a longer chain header rejects the request.
+ *   For non-RFC-9440 encodings the comma split may not match the encoding's list convention.
  * @property {'url-pem' | 'url-pem-aws' | 'xfcc' | 'base64-der' | 'rfc9440'} [headerEncoding] - Header encoding
  * @property {boolean} [fallbackToSocket=false] - Try socket if header extraction fails
  * @property {boolean} [includeChain=false] - Include issuerCertificate chain
@@ -259,16 +274,27 @@ export function extractClientCertificate(req, options = {}) {
       const chainHeaderValue = headers[chainHeaderName];
       // Only a non-empty string is parseable; anything else leaves the leaf unchained.
       if (typeof chainHeaderValue === 'string' && chainHeaderValue) {
-        const chainCerts = chainHeaderValue
+        const chainItems = chainHeaderValue
           .split(',')
           .map(item => item.trim())
-          .filter(Boolean)
-          .map(item => parseHeaderValue(item, chainEncoding, { chainInLeafHeader: false }))
           .filter(Boolean);
-        if (chainCerts.length > 0) {
-          cert.issuerCertificate = chainCerts[0];
-          for (let i = 0; i < chainCerts.length - 1; i++) {
-            chainCerts[i].issuerCertificate = chainCerts[i + 1];
+        if (chainItems.length + 1 > MAX_CHAIN_CERTS) {
+          cert = null;
+        } else {
+          const chainCerts = chainItems
+            .map(item => parseHeaderValue(item, chainEncoding, { chainInLeafHeader: false }))
+            .filter(Boolean);
+          // A single item can expand into several certificates (e.g. a
+          // multi-block url-pem), so bound the leaf plus every parsed
+          // certificate, not the item count.
+          const totalCerts = chainCerts.reduce((sum, c) => sum + countChain(c), 1);
+          if (totalCerts > MAX_CHAIN_CERTS) {
+            cert = null;
+          } else if (chainCerts.length > 0) {
+            cert.issuerCertificate = chainCerts[0];
+            for (let i = 0; i < chainCerts.length - 1; i++) {
+              chainCerts[i].issuerCertificate = chainCerts[i + 1];
+            }
           }
         }
       }

--- a/lib/parsers.d.ts
+++ b/lib/parsers.d.ts
@@ -130,3 +130,9 @@ export declare function getCertificateFromHeaders(
     headers: Record<string, string | string[] | undefined>,
     config: CertificateHeaderConfig
 ): ChainedPeerCertificate | null;
+
+/**
+ * Maximum number of certificates accepted from one header value (leaf plus chain).
+ * Longer inputs are rejected before any certificate is parsed.
+ */
+export declare const MAX_CHAIN_CERTS: number;

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -18,6 +18,12 @@ import { X509Certificate } from 'node:crypto';
  */
 
 /**
+ * Maximum number of certificates accepted from one header value (leaf plus
+ * chain). Longer inputs are rejected before any certificate is parsed.
+ */
+export const MAX_CHAIN_CERTS = 10;
+
+/**
  * Preset configurations for common reverse proxies.
  * Maps preset name to { header, encoding } configuration, with optional
  * `chainHeader` for two-header schemes (RFC 9440).
@@ -164,12 +170,15 @@ function splitPemBlocks(pem) {
  * chain information for `includeChain: true` consumers.
  *
  * @param {string} pem - Concatenated PEM blocks
- * @returns {ChainedPeerCertificate | null} Leaf cert with chain via issuerCertificate, or null if the leaf does not parse
+ * @returns {ChainedPeerCertificate | null} Leaf cert with chain via issuerCertificate, or null if the leaf does not parse or the blob exceeds MAX_CHAIN_CERTS
  */
 function chainFromMultiBlockPem(pem) {
     const pemBlocks = splitPemBlocks(pem);
     // Stryker disable next-line BlockStatement,ConditionalExpression: short-circuit; falling through hands undefined to pemToCertificate, which throws for the same null result
     if (pemBlocks.length === 0) {
+        return null;
+    }
+    if (pemBlocks.length > MAX_CHAIN_CERTS) {
         return null;
     }
 
@@ -397,7 +406,8 @@ export function parseXfcc(headerValue) {
 /**
  * Parse base64-encoded DER certificate (Cloudflare format).
  * Also handles Traefik's comma-separated cert chains - parses all certs
- * and links them via the issuerCertificate property.
+ * and links them via the issuerCertificate property. Empty entries after
+ * the leaf are ignored; more than MAX_CHAIN_CERTS entries reject the header.
  * 
  * @see https://developers.cloudflare.com/api-shield/security/mtls/configure/
  * @param {string} headerValue - Base64-encoded DER certificate(s)
@@ -421,6 +431,10 @@ export function parseBase64Der(headerValue, { chainInLeafHeader = true } = {}) {
     // Handle comma-separated cert chains (Traefik format)
     // Stryker disable next-line MethodExpression: .trim() no-op (base64 ignores whitespace)
     const certParts = headerValue.split(',').map(s => s.trim());
+    const chainParts = certParts.slice(1).filter(Boolean);
+    if (chainParts.length + 1 > MAX_CHAIN_CERTS) {
+        return null;
+    }
 
     // An empty or unparseable leaf rejects the whole header. Promoting the next
     // entry would authenticate the request as whichever certificate parsed first.
@@ -432,7 +446,7 @@ export function parseBase64Der(headerValue, { chainInLeafHeader = true } = {}) {
     }
 
     const certs = [leaf];
-    for (const base64 of certParts.slice(1)) {
+    for (const base64 of chainParts) {
         try {
             certs.push(derToCertificate(Buffer.from(base64, 'base64')));
         } catch {

--- a/test/test-unit-extractor.js
+++ b/test/test-unit-extractor.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import http from 'node:http';
 import net from 'node:net';
 import { extractClientCertificate, validateExtractorOptions } from '../lib/extractor.js';
+import { MAX_CHAIN_CERTS } from '../lib/parsers.js';
 import { pemToDer } from './test-helpers.js';
 
 /**
@@ -1109,6 +1110,63 @@ describe('extractClientCertificate', () => {
         assert.ok(result.certificate.issuerCertificate);
         assert.strictEqual(result.certificate.issuerCertificate.subject.CN, 'Intermediate CA');
         assert.strictEqual(result.certificate.issuerCertificate.issuerCertificate, undefined);
+      });
+    });
+
+    describe('chain header length cap', () => {
+      it('should reject a chain header that would exceed MAX_CHAIN_CERTS certificates with the leaf', () => {
+        const leafDer = pemToDer(testPem);
+        const makeReq = (count) => ({
+          headers: {
+            'client-cert': encodeAsRfc9440(leafDer),
+            'client-cert-chain': Array(count).fill(':x:').join(', '),
+          },
+          socket: { authorized: false },
+        });
+
+        const atCap = extractClientCertificate(makeReq(MAX_CHAIN_CERTS - 1), {
+          certificateSource: 'cloudflare-rfc9440',
+          includeChain: true,
+        });
+        assert.strictEqual(atCap.success, true);
+        assert.strictEqual(atCap.certificate.issuerCertificate, undefined);
+
+        const overCap = extractClientCertificate(makeReq(MAX_CHAIN_CERTS), {
+          certificateSource: 'cloudflare-rfc9440',
+          includeChain: true,
+        });
+        assert.strictEqual(overCap.success, false);
+        assert.strictEqual(overCap.certificate, null);
+        assert.strictEqual(overCap.reason, 'header_missing_or_malformed');
+      });
+
+      it('should count every certificate a single chain item expands into', () => {
+        // One url-pem item can carry several concatenated certificates, so the
+        // cap bounds the leaf plus every parsed certificate, not the
+        // comma-separated item count.
+        const multiBlock = (count) => encodeURIComponent(Array(count).fill(testPem).join('\n'));
+        const makeReq = (count) => ({
+          headers: {
+            'x-custom-cert': encodeURIComponent(testPem),
+            'x-custom-chain': multiBlock(count),
+          },
+          socket: { authorized: false },
+        });
+        const options = {
+          certificateHeader: 'X-Custom-Cert',
+          chainHeader: 'X-Custom-Chain',
+          headerEncoding: 'url-pem',
+          includeChain: true,
+        };
+
+        const atCap = extractClientCertificate(makeReq(MAX_CHAIN_CERTS - 1), options);
+        assert.strictEqual(atCap.success, true);
+        assert.ok(atCap.certificate.issuerCertificate);
+
+        const overCap = extractClientCertificate(makeReq(MAX_CHAIN_CERTS), options);
+        assert.strictEqual(overCap.success, false);
+        assert.strictEqual(overCap.certificate, null);
+        assert.strictEqual(overCap.reason, 'header_missing_or_malformed');
       });
     });
 

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -9,6 +9,7 @@ import {
     derToCertificate,
     parseHeaderValue,
     getCertificateFromHeaders,
+    MAX_CHAIN_CERTS,
     PRESETS,
 } from '../lib/parsers.js';
 import { generateClientCertificate, pemToDer } from './test-helpers.js';
@@ -125,6 +126,10 @@ describe('parsers module', () => {
             assert.equal(PRESETS['cloudflare-rfc9440'].header, 'client-cert');
             assert.equal(PRESETS['cloudflare-rfc9440'].chainHeader, 'client-cert-chain');
             assert.equal(PRESETS['cloudflare-rfc9440'].encoding, 'rfc9440');
+        });
+
+        it('should export MAX_CHAIN_CERTS', () => {
+            assert.equal(MAX_CHAIN_CERTS, 10);
         });
 
         it('should have traefik preset', () => {
@@ -273,6 +278,17 @@ describe('parsers module', () => {
         it('should return null when URL encoding is malformed', () => {
             // %G0 is not a valid percent-encoded sequence; decodeURIComponent throws.
             assert.equal(parseUrlPemAws('%G0'), null);
+        });
+
+        it('should accept up to MAX_CHAIN_CERTS PEM blocks and reject more before parsing', () => {
+            const atCap = parseUrlPemAws(encodeAsAwsAlb(Array(MAX_CHAIN_CERTS).fill(testPem).join('\n')));
+            assert.ok(atCap);
+            let depth = 0;
+            for (let c = atCap; c; c = c.issuerCertificate) {depth++;}
+            assert.equal(depth, MAX_CHAIN_CERTS);
+
+            const overCap = Array(MAX_CHAIN_CERTS + 1).fill(testPem).join('\n');
+            assert.equal(parseUrlPemAws(encodeAsAwsAlb(overCap)), null);
         });
 
         it('should stop scanning at a BEGIN marker with no matching END marker', () => {
@@ -773,6 +789,27 @@ describe('parsers module', () => {
             const invalidBase64 = Buffer.from('invalid-cert-data').toString('base64');
 
             assert.equal(parseBase64Der(`${invalidBase64},${validBase64}`), null);
+        });
+
+        it('should accept up to MAX_CHAIN_CERTS entries and reject more before parsing', () => {
+            const validBase64 = encodeAsCloudflare(testDer);
+            const atCap = parseBase64Der(Array(MAX_CHAIN_CERTS).fill(validBase64).join(','));
+            assert.ok(atCap);
+            let depth = 0;
+            for (let c = atCap; c; c = c.issuerCertificate) {depth++;}
+            assert.equal(depth, MAX_CHAIN_CERTS);
+
+            const junk = Array(MAX_CHAIN_CERTS).fill('x');
+            assert.equal(parseBase64Der([validBase64, ...junk].join(',')), null);
+        });
+
+        it('should not count empty entries after the leaf toward the cap', () => {
+            const validBase64 = encodeAsCloudflare(testDer);
+            const cert = parseBase64Der(validBase64 + ','.repeat(20000));
+
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+            assert.equal(cert.issuerCertificate, undefined);
         });
     });
 


### PR DESCRIPTION
Each header value carries at most MAX_CHAIN_CERTS (10) certificates, leaf and chain header counted together, checked before parsing. Stacked on #220.