### PR TITLE
fix(extractor): reject misconfigured options at construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Returns Express middleware.
 | `options.headerEncoding` | `string` | Encoding format: `'url-pem'`, `'url-pem-aws'`, `'xfcc'`, `'base64-der'`, `'rfc9440'` |
 | `options.fallbackToSocket` | `boolean` | If header extraction fails, try `socket.getPeerCertificate()` (default: `false`) |
 | `options.includeChain` | `boolean` | If `true`, include full certificate chain via `cert.issuerCertificate` (default: `false`) |
-| `options.verifyHeader` | `string` | Header name containing verification status from proxy (e.g., `'X-SSL-Client-Verify'`) |
+| `options.verifyHeader` | `string` | Header name containing verification status from proxy (e.g., `'X-SSL-Client-Verify'`). Requires `certificateSource` or `certificateHeader`, and must be paired with `verifyValue` |
 | `options.verifyValue` | `string` | Expected value indicating successful verification (e.g., `'SUCCESS'`) |
 | `options.onAuthenticated` | `(cert, req) => void` | Called on successful authentication (fire-and-forget) |
 | `options.onRejected` | `(cert, req, reason) => void` | Called on authentication failure (fire-and-forget) |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -184,7 +184,7 @@ Returns Express middleware that extracts a client certificate and passes it to y
 | `options.headerEncoding` | `string` | Encoding format: `'url-pem'`, `'url-pem-aws'`, `'xfcc'`, `'base64-der'`, `'rfc9440'` |
 | `options.fallbackToSocket` | `boolean` | If header extraction fails, try `socket.getPeerCertificate()` (default: `false`) |
 | `options.includeChain` | `boolean` | If `true`, include full certificate chain via `cert.issuerCertificate` (default: `false`) |
-| `options.verifyHeader` | `string` | Header name containing verification status from proxy (e.g., `'X-SSL-Client-Verify'`) |
+| `options.verifyHeader` | `string` | Header name containing verification status from proxy (e.g., `'X-SSL-Client-Verify'`). Requires `certificateSource` or `certificateHeader`, and must be paired with `verifyValue` |
 | `options.verifyValue` | `string` | Expected value indicating successful verification (e.g., `'SUCCESS'`) |
 | `options.onAuthenticated` | `(cert, req) => void` | Called on successful authentication (fire-and-forget) |
 | `options.onRejected` | `(cert, req, reason) => void` | Called on authentication failure (fire-and-forget) |

--- a/lib/clientCertificateAuth.cjs
+++ b/lib/clientCertificateAuth.cjs
@@ -108,6 +108,10 @@ function clientCertificateAuth(callback, options = {}) {
         throw new TypeError('client-certificate-auth: callback must be a function');
     }
 
+    if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+        throw new TypeError('client-certificate-auth: options must be an object');
+    }
+
     // Validate that no unsupported options are passed
     const used = UNSUPPORTED_OPTIONS.filter(k => options[k] !== undefined);
     if (used.length) {
@@ -118,6 +122,15 @@ function clientCertificateAuth(callback, options = {}) {
     }
 
     const { includeChain = false, onAuthenticated, onRejected } = options;
+
+    if (typeof includeChain !== 'boolean') {
+        throw new Error('client-certificate-auth: includeChain must be a boolean');
+    }
+    for (const [name, hook] of Object.entries({ onAuthenticated, onRejected })) {
+        if (hook !== undefined && typeof hook !== 'function') {
+            throw new TypeError(`client-certificate-auth: ${name} must be a function`);
+        }
+    }
 
     /**
      * Safely call a hook function without blocking or throwing.

--- a/lib/clientCertificateAuth.d.ts
+++ b/lib/clientCertificateAuth.d.ts
@@ -109,7 +109,9 @@ export interface ClientCertificateAuthOptions {
 
     /**
      * Header name containing certificate verification status from upstream proxy.
-     * Must be used together with verifyValue. Example: 'X-SSL-Client-Verify' for nginx.
+     * Must be used together with verifyValue, and requires certificateSource or
+     * certificateHeader: verification applies to header-based extraction only.
+     * Example: 'X-SSL-Client-Verify' for nginx.
      */
     verifyHeader?: string;
 

--- a/lib/clientCertificateAuth.js
+++ b/lib/clientCertificateAuth.js
@@ -92,7 +92,8 @@ function normalizeCallbackError(err) {
  * @property {boolean} [includeChain=false] - If true, include the full certificate chain via
  *   cert.issuerCertificate. Applies to both socket and header-based extraction.
  * @property {string} [verifyHeader] - Header name containing certificate verification status from
- *   upstream proxy (e.g., 'X-SSL-Client-Verify'). Must be used with verifyValue.
+ *   upstream proxy (e.g., 'X-SSL-Client-Verify'). Must be used with verifyValue, and requires
+ *   certificateSource or certificateHeader: verification applies to header-based extraction only.
  * @property {string} [verifyValue] - Expected value indicating successful verification (e.g., 'SUCCESS').
  *   If verifyHeader is set, requests are rejected unless the header matches this value.
  *   Comparison is exact (case-sensitive, no whitespace trimming); set this to the exact string your proxy emits.
@@ -154,6 +155,12 @@ export default function clientCertificateAuth(callback, options = {}) {
     onAuthenticated,
     onRejected,
   } = options;
+
+  for (const [name, hook] of Object.entries({ onAuthenticated, onRejected })) {
+    if (hook !== undefined && typeof hook !== 'function') {
+      throw new TypeError(`client-certificate-auth: ${name} must be a function`);
+    }
+  }
 
   /**
    * Safely call a hook function without blocking or throwing.

--- a/lib/extractor.d.ts
+++ b/lib/extractor.d.ts
@@ -18,8 +18,11 @@
  * @property {'url-pem' | 'url-pem-aws' | 'xfcc' | 'base64-der' | 'rfc9440'} [headerEncoding] - Header encoding
  * @property {boolean} [fallbackToSocket=false] - Try socket if header extraction fails
  * @property {boolean} [includeChain=false] - Include issuerCertificate chain
- * @property {string} [verifyHeader] - Header name for upstream verification status
- * @property {string} [verifyValue] - Expected value for successful verification
+ * @property {string} [verifyHeader] - Header name for upstream verification status. Pairs
+ *   with `verifyValue`, and requires `certificateSource` or `certificateHeader`:
+ *   verification applies to header-based extraction only.
+ * @property {string} [verifyValue] - Expected value for successful verification. Pairs
+ *   with `verifyHeader`.
  */
 /**
  * Extract client certificate from request.
@@ -61,9 +64,12 @@ export function extractClientCertificate(req: {
 }, options?: ExtractorOptions): ExtractionResult;
 /**
  * Validate options shared by `extractClientCertificate` and the middleware constructor.
- * Throws on unknown `certificateSource`, unknown `headerEncoding`,
- * `certificateHeader` without an encoding source, or only one of `verifyHeader`/`verifyValue`.
- * Omitted or `undefined` options are treated as the empty object; explicit `null` throws.
+ * Throws on an unknown `certificateSource` or `headerEncoding`, a header-name option that
+ * is not a non-empty string, a flag that is not a boolean, `certificateHeader` without an
+ * encoding source, `chainHeader` or `verifyHeader` without a leaf header source, or only
+ * one of `verifyHeader`/`verifyValue`.
+ * Omitted or `undefined` options are treated as the empty object; any other non-object
+ * value, `null` and arrays among them, throws a `TypeError`.
  */
 export function validateExtractorOptions(options?: ExtractorOptions): void;
 export type ExtractionResult = {
@@ -112,11 +118,13 @@ export type ExtractorOptions = {
      */
     includeChain?: boolean;
     /**
-     * - Header name for upstream verification status
+     * - Header name for upstream verification status. Pairs with `verifyValue`, and
+     * requires `certificateSource` or `certificateHeader`: verification applies to
+     * header-based extraction only.
      */
     verifyHeader?: string;
     /**
-     * - Expected value for successful verification
+     * - Expected value for successful verification. Pairs with `verifyHeader`.
      */
     verifyValue?: string;
 };

--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -10,45 +10,78 @@ const VALID_ENCODINGS = ['url-pem', 'url-pem-aws', 'xfcc', 'base64-der', 'rfc944
 
 /**
  * Validate options shared by `extractClientCertificate` and the middleware
- * constructor. Throws on misconfiguration (unknown preset, unknown encoding,
- * `certificateHeader` without an encoding source, `chainHeader` without a
- * leaf header source, or only one of `verifyHeader`/`verifyValue`). Omitted
- * or `undefined` options are treated as the empty object; explicit `null`
- * will throw a `TypeError`.
+ * constructor. Throws on misconfiguration: an unknown preset or encoding, a
+ * header-name option that is not a non-empty string, a flag that is not a
+ * boolean, `certificateHeader` without an encoding source, `chainHeader` or
+ * `verifyHeader` without a leaf header source, or only one of
+ * `verifyHeader`/`verifyValue`. Omitted or `undefined` options are treated
+ * as the empty object; any other non-object value, `null` and arrays among
+ * them, throws a `TypeError`.
  *
  * @param {ExtractorOptions} [options]
  * @throws {Error} when options are malformed
  */
 export function validateExtractorOptions(options = {}) {
-  const { certificateSource, certificateHeader, chainHeader, headerEncoding, verifyHeader, verifyValue } = options;
+  if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+    throw new TypeError('client-certificate-auth: options must be an object');
+  }
 
-  if ((verifyHeader && !verifyValue) || (!verifyHeader && verifyValue)) {
+  const {
+    certificateSource,
+    certificateHeader,
+    chainHeader,
+    headerEncoding,
+    fallbackToSocket,
+    includeChain,
+    verifyHeader,
+    verifyValue,
+  } = options;
+
+  for (const [name, value] of Object.entries({ certificateHeader, chainHeader, verifyHeader, verifyValue })) {
+    if (value !== undefined && (typeof value !== 'string' || value === '')) {
+      throw new Error(`client-certificate-auth: ${name} must be a non-empty string`);
+    }
+  }
+
+  for (const [name, value] of Object.entries({ fallbackToSocket, includeChain })) {
+    if (value !== undefined && typeof value !== 'boolean') {
+      throw new Error(`client-certificate-auth: ${name} must be a boolean`);
+    }
+  }
+
+  if ((verifyHeader === undefined) !== (verifyValue === undefined)) {
     throw new Error(
       'client-certificate-auth: verifyHeader and verifyValue must both be provided together, or both omitted'
     );
   }
 
-  if (certificateSource && !Object.hasOwn(PRESETS, certificateSource)) {
+  if (certificateSource !== undefined && !Object.hasOwn(PRESETS, certificateSource)) {
     throw new Error(
       `client-certificate-auth: unknown certificateSource '${certificateSource}'. Valid values: ${Object.keys(PRESETS).join(', ')}`
     );
   }
 
-  if (headerEncoding && !VALID_ENCODINGS.includes(headerEncoding)) {
+  if (headerEncoding !== undefined && !VALID_ENCODINGS.includes(headerEncoding)) {
     throw new Error(
       `client-certificate-auth: unknown headerEncoding '${headerEncoding}'. Valid values: ${VALID_ENCODINGS.join(', ')}`
     );
   }
 
-  if (certificateHeader && !certificateSource && !headerEncoding) {
+  if (certificateHeader !== undefined && certificateSource === undefined && headerEncoding === undefined) {
     throw new Error(
       'client-certificate-auth: certificateHeader requires headerEncoding (or a certificateSource preset that supplies one)'
     );
   }
 
-  if (chainHeader && !certificateSource && !certificateHeader) {
+  if (chainHeader !== undefined && certificateSource === undefined && certificateHeader === undefined) {
     throw new Error(
       'client-certificate-auth: chainHeader requires certificateSource or certificateHeader (chain header must accompany a leaf header configuration)'
+    );
+  }
+
+  if (verifyHeader !== undefined && certificateSource === undefined && certificateHeader === undefined) {
+    throw new Error(
+      'client-certificate-auth: verifyHeader requires certificateSource or certificateHeader (verification applies to header-based extraction only)'
     );
   }
 }
@@ -81,8 +114,11 @@ export function validateExtractorOptions(options = {}) {
  * @property {'url-pem' | 'url-pem-aws' | 'xfcc' | 'base64-der' | 'rfc9440'} [headerEncoding] - Header encoding
  * @property {boolean} [fallbackToSocket=false] - Try socket if header extraction fails
  * @property {boolean} [includeChain=false] - Include issuerCertificate chain
- * @property {string} [verifyHeader] - Header name for upstream verification status
- * @property {string} [verifyValue] - Expected value for successful verification
+ * @property {string} [verifyHeader] - Header name for upstream verification status. Pairs
+ *   with `verifyValue`, and requires `certificateSource` or `certificateHeader`:
+ *   verification applies to header-based extraction only.
+ * @property {string} [verifyValue] - Expected value for successful verification. Pairs
+ *   with `verifyHeader`.
  */
 
 /**

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-import { extractClientCertificate } from './extractor.js';
+import { extractClientCertificate, validateExtractorOptions } from './extractor.js';
 
 /**
  * @typedef {import('./extractor.js').ExtractorOptions} ExtractorOptions
@@ -46,6 +46,10 @@ import { extractClientCertificate } from './extractor.js';
  * }
  */
 export function extractClientCertificateFromRequest(request, options = {}) {
+  // Validated here as well as in the extractor: fallbackToSocket is stripped
+  // below and would otherwise never be checked.
+  validateExtractorOptions(options);
+
   // Web Headers normalizes to lowercase, but Map and other iterables
   // preserve casing. Normalize here for the core extractor's lowercase lookup.
   const headers = Object.create(null);

--- a/test/test-unit-clientCertificateAuth.cjs
+++ b/test/test-unit-clientCertificateAuth.cjs
@@ -47,6 +47,17 @@ describe('clientCertificateAuth (CommonJS)', () => {
         assert.equal(typeof clientCertificateAuth.load, 'function');
     });
 
+    it('should throw TypeError if options is not an object', () => {
+        assert.throws(() => clientCertificateAuth(() => true, 'aws-alb'), {
+            name: 'TypeError',
+            message: /options must be an object/
+        });
+        assert.throws(() => clientCertificateAuth(() => true, []), {
+            name: 'TypeError',
+            message: /options must be an object/
+        });
+    });
+
     it('should throw TypeError if callback is not a function', () => {
         assert.throws(() => clientCertificateAuth('not a function'), {
             name: 'TypeError',
@@ -1100,6 +1111,33 @@ describe('clientCertificateAuth (CommonJS)', () => {
 
         it('should not throw when an unsupported option is explicitly undefined', () => {
             assert.doesNotThrow(() => clientCertificateAuth(() => true, { certificateSource: undefined }));
+        });
+
+        it('should throw when includeChain is not a boolean', () => {
+            assert.throws(
+                () => clientCertificateAuth(() => true, { includeChain: 'yes' }),
+                {
+                    name: 'Error',
+                    message: /includeChain must be a boolean/
+                }
+            );
+        });
+
+        it('should throw when onAuthenticated or onRejected is not a function', () => {
+            assert.throws(
+                () => clientCertificateAuth(() => true, { onAuthenticated: 'log' }),
+                {
+                    name: 'TypeError',
+                    message: /onAuthenticated must be a function/
+                }
+            );
+            assert.throws(
+                () => clientCertificateAuth(() => true, { onRejected: null }),
+                {
+                    name: 'TypeError',
+                    message: /onRejected must be a function/
+                }
+            );
         });
 
         it('should include load() guidance in error message', () => {

--- a/test/test-unit-clientCertificateAuth.js
+++ b/test/test-unit-clientCertificateAuth.js
@@ -875,23 +875,6 @@ describe('clientCertificateAuth', () => {
           });
         });
 
-        it('should not check verifyHeader for socket-based extraction', done => {
-          // Socket-based auth should ignore verifyHeader
-          const middleware = clientCertificateAuth((cert) => {
-            assert.equal(cert.subject.CN, 'Proctor Davenport');
-            return true;
-          }, {
-            verifyHeader: 'X-SSL-Client-Verify',
-            verifyValue: 'SUCCESS'
-            // No certificateSource or certificateHeader = socket-based
-          });
-
-          middleware(mockGoodReq, mockRes, (err) => {
-            assert.equal(err, undefined);
-            done();
-          });
-        });
-
         it('should throw at construction when only verifyHeader is set (no verifyValue)', () => {
           assert.throws(
             () => clientCertificateAuth(() => true, {
@@ -1001,6 +984,59 @@ describe('clientCertificateAuth', () => {
           {
             name: 'Error',
             message: /unknown headerEncoding 'url-perm'/
+          }
+        );
+      });
+
+      it('should throw when verifyHeader and verifyValue are set without a header source', () => {
+        assert.throws(
+          () => clientCertificateAuth(() => true, {
+            verifyHeader: 'X-SSL-Client-Verify',
+            verifyValue: 'SUCCESS'
+          }),
+          {
+            name: 'Error',
+            message: /verifyHeader requires certificateSource or certificateHeader/
+          }
+        );
+      });
+
+        it('should throw when the options argument is not an object', () => {
+            assert.throws(
+                () => clientCertificateAuth(() => true, 'aws-alb'),
+                {
+                    name: 'TypeError',
+                    message: /options must be an object/
+                }
+            );
+        });
+
+      it('should throw when fallbackToSocket is not a boolean', () => {
+        assert.throws(
+          () => clientCertificateAuth(() => true, {
+            certificateSource: 'aws-alb',
+            fallbackToSocket: 'false'
+          }),
+          {
+            name: 'Error',
+            message: /fallbackToSocket must be a boolean/
+          }
+        );
+      });
+
+      it('should throw when onAuthenticated or onRejected is not a function', () => {
+        assert.throws(
+          () => clientCertificateAuth(() => true, { onAuthenticated: 'log' }),
+          {
+            name: 'TypeError',
+            message: /onAuthenticated must be a function/
+          }
+        );
+        assert.throws(
+          () => clientCertificateAuth(() => true, { onRejected: null }),
+          {
+            name: 'TypeError',
+            message: /onRejected must be a function/
           }
         );
       });

--- a/test/test-unit-extractor.js
+++ b/test/test-unit-extractor.js
@@ -83,9 +83,81 @@ describe('extractClientCertificate', () => {
       const req = { headers: {}, socket: { authorized: false } };
       assert.doesNotThrow(() =>
         extractClientCertificate(req, {
+          certificateSource: 'aws-alb',
           verifyHeader: 'X-Verify',
           verifyValue: 'SUCCESS',
         })
+      );
+    });
+
+    it('should throw when verifyHeader and verifyValue are set without a header source', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      assert.throws(
+        () => extractClientCertificate(req, { verifyHeader: 'X-Verify', verifyValue: 'SUCCESS' }),
+        { name: 'Error', message: /verifyHeader requires certificateSource or certificateHeader/ }
+      );
+    });
+
+    it('should throw when verifyHeader or verifyValue is an empty string', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      assert.throws(
+        () => extractClientCertificate(req, { certificateSource: 'aws-alb', verifyHeader: '', verifyValue: '' }),
+        { name: 'Error', message: /verifyHeader must be a non-empty string/ }
+      );
+      assert.throws(
+        () => extractClientCertificate(req, { certificateSource: 'aws-alb', verifyHeader: 'X-Verify', verifyValue: '' }),
+        { name: 'Error', message: /verifyValue must be a non-empty string/ }
+      );
+    });
+
+    it('should throw when a header-name option is not a string', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      for (const [option, value] of [['certificateHeader', 42], ['chainHeader', null], ['verifyHeader', ['X-Verify']]]) {
+        assert.throws(
+          () => extractClientCertificate(req, {
+            certificateSource: 'aws-alb',
+            verifyValue: option === 'verifyHeader' ? 'SUCCESS' : undefined,
+            [option]: value,
+          }),
+          { name: 'Error', message: new RegExp(`${option} must be a non-empty string`) },
+          `${option} should reject ${JSON.stringify(value)}`
+        );
+      }
+    });
+
+    it('should throw when certificateHeader or chainHeader is an empty string', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      assert.throws(
+        () => extractClientCertificate(req, { certificateHeader: '', headerEncoding: 'url-pem' }),
+        { name: 'Error', message: /certificateHeader must be a non-empty string/ }
+      );
+      assert.throws(
+        () => extractClientCertificate(req, { certificateSource: 'aws-alb', chainHeader: '' }),
+        { name: 'Error', message: /chainHeader must be a non-empty string/ }
+      );
+    });
+
+    it('should throw when fallbackToSocket or includeChain is not a boolean', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      assert.throws(
+        () => extractClientCertificate(req, { certificateSource: 'aws-alb', fallbackToSocket: 'false' }),
+        { name: 'Error', message: /fallbackToSocket must be a boolean/ }
+      );
+      assert.throws(
+        () => extractClientCertificate(req, { includeChain: 1 }),
+        { name: 'Error', message: /includeChain must be a boolean/ }
+      );
+    });
+
+    it('should throw when certificateSource or headerEncoding is an empty string', () => {
+      const req = { headers: {}, socket: { authorized: false } };
+      assert.throws(
+        () => extractClientCertificate(req, { certificateSource: '' }),
+        { name: 'Error', message: /unknown certificateSource ''/ }
+      );
+      assert.throws(
+        () => extractClientCertificate(req, { certificateHeader: 'X-Cert', headerEncoding: '' }),
+        { name: 'Error', message: /unknown headerEncoding ''/ }
       );
     });
 
@@ -187,8 +259,21 @@ describe('extractClientCertificate', () => {
       assert.doesNotThrow(() => validateExtractorOptions());
     });
 
-    it('should throw TypeError when validateExtractorOptions is called with null', () => {
-      assert.throws(() => validateExtractorOptions(null), { name: 'TypeError' });
+    it('should throw TypeError for a container that is not a plain object', () => {
+      for (const value of [null, 'aws-alb', 42, true, [], ['aws-alb'], () => {}, Symbol('x')]) {
+        assert.throws(
+          () => validateExtractorOptions(/** @type {any} */ (value)),
+          { name: 'TypeError', message: /options must be an object/ },
+          `expected ${String(value)} to be rejected`
+        );
+      }
+    });
+
+    it('should reject a non-object container from extractClientCertificate', () => {
+      assert.throws(
+        () => extractClientCertificate({ headers: {} }, /** @type {any} */ ('aws-alb')),
+        { name: 'TypeError', message: /options must be an object/ }
+      );
     });
   });
 
@@ -1270,27 +1355,6 @@ describe('extractClientCertificate', () => {
       assert.strictEqual(result.reason, 'verification_header_mismatch');
     });
 
-    it('should not check verification header for socket-based extraction', () => {
-      const mockCert = getMockPeerCertificate();
-      const req = {
-        headers: {
-          'x-ssl-client-verify': 'FAILED', // Mismatch, but should be ignored for socket
-        },
-        socket: {
-          authorized: true,
-          getPeerCertificate: () => mockCert,
-        },
-      };
-
-      // No certificateSource/certificateHeader, so should use socket only
-      const result = extractClientCertificate(req, {
-        verifyHeader: 'X-SSL-Client-Verify',
-        verifyValue: 'SUCCESS',
-      });
-
-      assert.strictEqual(result.success, true);
-      assert.deepStrictEqual(result.certificate, mockCert);
-    });
   });
 
   describe('AWS ALB safe characters', () => {

--- a/test/test-unit-fetch.js
+++ b/test/test-unit-fetch.js
@@ -49,6 +49,19 @@ describe('extractClientCertificateFromRequest', () => {
     });
   });
 
+  describe('option validation', () => {
+    it('should validate fallbackToSocket before stripping it', () => {
+      const request = new Request('https://example.com/api', { headers: {} });
+      assert.throws(
+        () => extractClientCertificateFromRequest(request, {
+          certificateSource: 'cloudflare-rfc9440',
+          fallbackToSocket: 'yes',
+        }),
+        { name: 'Error', message: /fallbackToSocket must be a boolean/ }
+      );
+    });
+  });
+
   describe('with Web Request', () => {
     it('should extract certificate via cloudflare-rfc9440 preset from a Web Request', () => {
       const request = new Request('https://example.com/api', {


### PR DESCRIPTION
Header-name options must be non-empty strings, flags must be booleans, the verify pair requires a header source, and hooks must be functions. Stacked on #204.