### PR TITLE
test(mtls): guard the includeChain socket test against nodejs/node#65579

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ app.use(clientCertificateAuth((cert) => {
 }, { includeChain: true }));
 ```
 
-When `includeChain: true`, the certificate object includes `issuerCertificate` linking to the issuer's certificate (and so on up the chain). This works consistently for both socket-based and header-based extraction.
+When `includeChain: true`, the certificate object includes `issuerCertificate` linking to the issuer's certificate (and so on up the chain). This works consistently for both socket-based and header-based extraction, except on Node.js 26.8.0 and later, where a Node.js regression ([nodejs/node#65579](https://github.com/nodejs/node/issues/65579)) leaves `issuerCertificate` unset on the socket path; header-based extraction is unaffected. See [Troubleshooting](docs/guide/troubleshooting.md#certificate-chain-missing-on-nodejs-2680-and-later).
 
 For header-based extraction the first certificate in the header is the leaf. If it is empty or unparseable the header is rejected with `header_missing_or_malformed` rather than promoting the next certificate into the leaf position. See [Reverse Proxy Setup](https://tgies.github.io/client-certificate-auth/guide/reverse-proxy#chains-in-a-single-header) for the per-encoding details.
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -44,6 +44,18 @@ Also confirm that the client is actually sending a certificate. Tools like `open
 openssl s_client -connect localhost:443 -cert client.pem -key client.key
 ```
 
+## Certificate chain missing on Node.js 26.8.0 and later
+
+On Node.js 26.8.0 and later, socket-based extraction with `includeChain: true` returns the leaf certificate with `issuerCertificate` unset, even when the client presented the full chain. This is a Node.js regression ([nodejs/node#65579](https://github.com/nodejs/node/issues/65579), fix [nodejs/node#65602](https://github.com/nodejs/node/pull/65602)): the server-side `getPeerCertificate(true)` no longer exposes the peer chain.
+
+Only the direct TLS socket path is affected. Header-based extraction (reverse proxies) is unaffected, because this library builds those chains itself.
+
+Until the fix ships, on the socket path:
+
+- Pin the certificate with [`allowFingerprints`](./helpers) - it matches the leaf and does not use the chain.
+- Or verify with [`allowCA`](./helpers) and include the issuing intermediate(s) in its CA set, so the leaf validates directly (the presented chain is unavailable).
+- Or run Node.js < 26.8.0.
+
 ## Reverse Proxy Headers Not Working
 
 When using header-based certificate extraction behind a reverse proxy:

--- a/test/test-integration-mtls.js
+++ b/test/test-integration-mtls.js
@@ -452,6 +452,7 @@ describe('includeChain mTLS Integration', () => {
     let server;
     let serverPort;
     let capturedCert;
+    let runtimeExposesPeerChain;
 
     beforeAll(async () => {
         const certs = await generateMtlsCertificates();
@@ -466,7 +467,55 @@ describe('includeChain mTLS Integration', () => {
             key: chain.client.key,
             cert: `${chain.client.cert}\n${chain.intermediate.cert}`,
         };
+        runtimeExposesPeerChain = await probePeerChainExposure();
     });
+
+    // Node >= 26.8.0 stopped exposing the server-side peer certificate chain
+    // via getPeerCertificate(true) (nodejs/node#65579, fix nodejs/node#65602):
+    // an internal getPeerX509Certificate() call caches a chainless leaf. Probe
+    // the running Node once, with a raw handshake, so the assertions adapt to a
+    // runtime the library cannot work around instead of failing on it.
+    function probePeerChainExposure() {
+        return new Promise((resolve, reject) => {
+            let exposed = false;
+            const probe = https.createServer(
+                {
+                    key: serverPems.key,
+                    cert: serverPems.cert,
+                    ca: [caPems.cert],
+                    requestCert: true,
+                    rejectUnauthorized: false,
+                },
+                (req, res) => {
+                    const cert = req.socket.getPeerCertificate(true);
+                    exposed = Boolean(cert && cert.issuerCertificate);
+                    res.writeHead(200);
+                    res.end();
+                },
+            );
+            const fail = (err) => probe.close(() => reject(err));
+            probe.on('error', fail);
+            probe.listen(0, 'localhost', () => {
+                const req = https.request(
+                    {
+                        hostname: 'localhost',
+                        port: probe.address().port,
+                        method: 'GET',
+                        key: chainClientPems.key,
+                        cert: chainClientPems.cert,
+                        ca: [caPems.cert],
+                        rejectUnauthorized: true,
+                    },
+                    (res) => {
+                        res.resume();
+                        res.on('end', () => probe.close(() => resolve(exposed)));
+                    },
+                );
+                req.on('error', fail);
+                req.end();
+            });
+        });
+    }
 
     function startServer(middlewareOptions, done) {
         capturedCert = null;
@@ -533,12 +582,17 @@ describe('includeChain mTLS Integration', () => {
                         assert.equal(res.statusCode, 200);
                         assert.ok(capturedCert, 'validation callback was not invoked');
                         assert.equal(capturedCert.subject.CN, 'Test Chain Client');
-                        const issuer = capturedCert.issuerCertificate;
-                        assert.ok(issuer, 'cert.issuerCertificate should be present');
-                        assert.equal(issuer.subject.CN, 'Test Intermediate CA');
-                        const root = issuer.issuerCertificate;
-                        assert.ok(root, 'intermediate.issuerCertificate should be present');
-                        assert.equal(root.subject.CN, 'Test CA');
+                        // On Node without the nodejs/node#65579 regression the
+                        // socket path surfaces the full chain; where Node drops
+                        // it, the leaf above is all that can be checked here.
+                        if (runtimeExposesPeerChain) {
+                            const issuer = capturedCert.issuerCertificate;
+                            assert.ok(issuer, 'cert.issuerCertificate should be present');
+                            assert.equal(issuer.subject.CN, 'Test Intermediate CA');
+                            const root = issuer.issuerCertificate;
+                            assert.ok(root, 'intermediate.issuerCertificate should be present');
+                            assert.equal(root.subject.CN, 'Test CA');
+                        }
                         done();
                     } catch (err) {
                         done(err);


### PR DESCRIPTION
Guards the includeChain socket integration test against a Node.js regression: Node 26.8.0 stopped exposing the server-side peer certificate chain via `getPeerCertificate(true)` ([nodejs/node#65579](https://github.com/nodejs/node/issues/65579), fix [nodejs/node#65602](https://github.com/nodejs/node/pull/65602)). The test now asserts the chain only when the runtime exposes it, and README plus the troubleshooting guide document the regression and workarounds.

Supersedes #225.