### PR TITLE
fix(parsers): split XFCC pairs on semicolons outside quotes

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -225,6 +225,77 @@ export function parseUrlPemAws(headerValue) {
 }
 
 /**
+ * A double quote ends the quoted value it opened unless a backslash precedes
+ * it, the form Envoy escapes an embedded quote into. Reading it that way never
+ * lets a quoted value end early, so a value cannot close its own quoting and
+ * go on to contribute XFCC pairs of its own.
+ *
+ * Envoy escapes an embedded quote but not an embedded backslash, so a value
+ * ending in one arrives as `\"` and is indistinguishable on the wire from an
+ * escaped quote. Such a value reads as unterminated and its element is
+ * rejected. Counting the backslash run instead would read an even run as
+ * escaping itself, closing the quoting at `...\\"` and letting the value that
+ * carries it inject a `Cert=` pair of its own.
+ *
+ * @param {string} text
+ * @param {number} i
+ * @returns {boolean}
+ */
+function isQuoteDelimiter(text, i) {
+    // Stryker disable next-line ConditionalExpression: i===0 → false still works because str[-1] is undefined
+    return text[i] === '"' && (i === 0 || text[i - 1] !== '\\');
+}
+
+/**
+ * The first XFCC element: the text up to the first comma outside double
+ * quotes. Later proxy hops are not parsed, so scanning stops there.
+ *
+ * @param {string} text - XFCC header value
+ * @returns {string | null} The first element, or null if it leaves a quoted value open
+ */
+function firstXfccElement(text) {
+    let inQuote = false;
+    // Stryker disable next-line EqualityOperator: i <= length reads undefined, same result
+    for (let i = 0; i < text.length; i++) {
+        if (isQuoteDelimiter(text, i)) {
+            inQuote = !inQuote;
+        } else if (text[i] === ',' && !inQuote) {
+            return text.substring(0, i);
+        }
+    }
+    // An element that never closes its quoting is malformed; parsing on would
+    // read every remaining delimiter as part of the value.
+    return inQuote ? null : text;
+}
+
+/**
+ * Split XFCC text on a delimiter that appears outside double quotes. Envoy
+ * quotes any field whose value contains one, so a Subject DN of
+ * `CN=client,OU=team;L=Austin` arrives as `Subject="CN=client,OU=team;L=Austin"`
+ * and must not be broken apart on the delimiters it carries.
+ *
+ * @param {string} text - XFCC element with balanced quoting
+ * @param {string} delimiter - Single delimiter character
+ * @returns {string[]} Segments, delimiters removed
+ */
+function splitOutsideQuotes(text, delimiter) {
+    const parts = [];
+    let start = 0;
+    let inQuote = false;
+    // Stryker disable next-line EqualityOperator: i <= length reads undefined, same result
+    for (let i = 0; i < text.length; i++) {
+        if (isQuoteDelimiter(text, i)) {
+            inQuote = !inQuote;
+        } else if (text[i] === delimiter && !inQuote) {
+            parts.push(text.substring(start, i));
+            start = i + 1;
+        }
+    }
+    parts.push(text.substring(start));
+    return parts;
+}
+
+/**
  * Parse Envoy XFCC (X-Forwarded-Client-Cert) structured header format.
  * Format: Key=Value;Key=Value;... where Cert (single URL-encoded PEM) or
  * Chain (URL-encoded multi-block PEM with the full chain incl. leaf) carry
@@ -245,25 +316,14 @@ export function parseXfcc(headerValue) {
     try {
         // XFCC may contain multiple comma-separated elements from different
         // proxy hops. We care about the first element (the original client).
-        // We split on the first comma outside double quotes, because quoted
-        // fields like Subject="CN=client,OU=team" can contain literal commas.
-        let endOfFirst = headerValue.length;
-        let inQuote = false;
-        // Stryker disable next-line EqualityOperator: i <= length reads undefined, same result
-        for (let i = 0; i < headerValue.length; i++) {
-            // Stryker disable next-line ConditionalExpression: i===0 → false still works because str[-1] is undefined
-            if (headerValue[i] === '"' && (i === 0 || headerValue[i - 1] !== '\\')) {
-                inQuote = !inQuote;
-            } else if (headerValue[i] === ',' && !inQuote) {
-                endOfFirst = i;
-                break;
-            }
+        const firstElement = firstXfccElement(headerValue);
+        if (firstElement === null) {
+            return null;
         }
-        const firstElement = headerValue.substring(0, endOfFirst);
 
         // Parse key=value pairs separated by semicolons. Collect Cert and
         // Chain values; prefer Chain when both are present.
-        const pairs = firstElement.split(';');
+        const pairs = splitOutsideQuotes(firstElement, ';');
         let certValue = null;
         let chainValue = null;
 
@@ -290,9 +350,17 @@ export function parseXfcc(headerValue) {
                     // than parse the cert content out of the broken wrapping.
                     return null;
                 }
+                // No proxy sends either key twice in one element, so a repeat
+                // is an injected pair rather than a value to choose between.
                 if (key === 'chain') {
+                    if (chainValue !== null) {
+                        return null;
+                    }
                     chainValue = value;
                 } else {
+                    if (certValue !== null) {
+                        return null;
+                    }
                     certValue = value;
                 }
             }

--- a/test/test-unit-parsers.js
+++ b/test/test-unit-parsers.js
@@ -352,22 +352,18 @@ describe('parsers module', () => {
         });
 
         it('should return null when value has only starting quote (malformed)', () => {
-            // Tests: value.startsWith('"') && value.endsWith('"')
-            // If only one quote is present, the quote becomes part of the value
-            // and breaks URL decoding or certificate parsing
+            // One quote leaves the element's quoting open, so it is rejected
+            // before any value is read.
             const encodedPem = encodeURIComponent(testPem);
-            const xfcc = `Hash=abc;Cert="${encodedPem}`;  // Missing end quote
+            const xfcc = `Hash=abc;Cert="${encodedPem}`;
             const cert = parseXfcc(xfcc);
-            // Fails because leading quote becomes part of value
             assert.equal(cert, null);
         });
 
         it('should return null when value has only ending quote (malformed)', () => {
-            // Tests: value.startsWith('"') && value.endsWith('"')
             const encodedPem = encodeURIComponent(testPem);
-            const xfcc = `Hash=abc;Cert=${encodedPem}"`;  // Only end quote
+            const xfcc = `Hash=abc;Cert=${encodedPem}"`;
             const cert = parseXfcc(xfcc);
-            // Fails because trailing quote becomes part of value
             assert.equal(cert, null);
         });
 
@@ -419,6 +415,89 @@ describe('parsers module', () => {
 
             assert.ok(cert, 'Should not be broken by commas inside quoted Subject');
             assert.equal(cert.subject.CN, 'Test Parser Client');
+        });
+
+        it('should handle quoted Subject fields containing semicolons', () => {
+            const encodedPem = encodeURIComponent(testPem);
+            const xfcc = `Subject="CN=client;OU=team";Cert="${encodedPem}"`;
+            const cert = parseXfcc(xfcc);
+
+            assert.ok(cert, 'Should not be broken by semicolons inside quoted Subject');
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+        });
+
+        it('should not take a Cert pair injected into a quoted Subject', async () => {
+            const forged = await generateClientCertificate('Forged Client');
+            const encodedPem = encodeURIComponent(testPem);
+            const encodedForged = encodeURIComponent(forged.cert);
+            // A client whose DN carries semicolons controls this text; splitting
+            // the element on them would let the DN contribute its own pairs.
+            const xfcc = `Cert="${encodedPem}";Subject="CN=x;Cert=${encodedForged};OU=y"`;
+            const cert = parseXfcc(xfcc);
+
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+        });
+
+        it('should not take a Chain pair injected into a quoted Subject', async () => {
+            const forged = await generateClientCertificate('Forged Client');
+            const encodedPem = encodeURIComponent(testPem);
+            const encodedForged = encodeURIComponent(forged.cert);
+            const xfcc = `Cert="${encodedPem}";Subject="CN=x;Chain=${encodedForged};OU=y"`;
+            const cert = parseXfcc(xfcc);
+
+            assert.ok(cert);
+            assert.equal(cert.subject.CN, 'Test Parser Client');
+        });
+
+        it('should reject an element that leaves a quoted value open', () => {
+            const encodedPem = encodeURIComponent(testPem);
+            // Parsing on would read every remaining delimiter as part of the value.
+            assert.equal(parseXfcc(`Cert="${encodedPem}";Subject="CN=unterminated`), null);
+            assert.equal(parseXfcc(`Subject="CN=unterminated,Cert="${encodedPem}"`), null);
+
+            const closed = parseXfcc(`Cert="${encodedPem}";Subject="CN=closed"`);
+            assert.ok(closed);
+            assert.equal(closed.subject.CN, 'Test Parser Client');
+        });
+
+        it('should reject a value quoted on only one side', () => {
+            const encodedPem = encodeURIComponent(testPem);
+            // Element quoting is balanced, so this reaches the per-value check.
+            assert.equal(parseXfcc(`Cert="${encodedPem}"x`), null);
+            assert.equal(parseXfcc(`Cert=x"${encodedPem}"`), null);
+        });
+
+        it('should reject a value ending in a backslash rather than resolve the ambiguity', async () => {
+            const forged = await generateClientCertificate('Forged Client');
+            const encodedPem = encodeURIComponent(testPem);
+            const encodedForged = encodeURIComponent(forged.cert);
+            // Envoy escapes an embedded quote but not an embedded backslash, so
+            // a DN ending in one is indistinguishable from an escaped quote.
+            assert.equal(parseXfcc(`Subject="CN=ends\\";Cert="${encodedPem}"`), null);
+            // An even run reads the same way here; run-parity would close the
+            // quoting on it instead.
+            assert.equal(parseXfcc(`Subject="CN=ends\\\\";Cert="${encodedPem}"`), null);
+            // Resolving it the other way would close the quoting here and take
+            // the pair the value carries; keeping it open leaves the genuine
+            // Cert as the only one the element contributes.
+            const kept = parseXfcc(`Cert="${encodedPem}";URI="a\\\\";Cert=${encodedForged}"`);
+            assert.ok(kept);
+            assert.equal(kept.subject.CN, 'Test Parser Client');
+        });
+
+        it('should reject an element carrying two Cert pairs', async () => {
+            const forged = await generateClientCertificate('Forged Client');
+            const xfcc = `Cert="${encodeURIComponent(testPem)}";Cert="${encodeURIComponent(forged.cert)}"`;
+
+            assert.equal(parseXfcc(xfcc), null);
+        });
+
+        it('should reject an element carrying two Chain pairs', async () => {
+            const forged = await generateClientCertificate('Forged Client');
+            const xfcc = `Chain="${encodeURIComponent(testPem)}";Chain="${encodeURIComponent(forged.cert)}"`;
+
+            assert.equal(parseXfcc(xfcc), null);
         });
 
         it('should handle escaped quotes inside quoted values', () => {


### PR DESCRIPTION
XFCC quotes any field whose value contains a semicolon, but `parseXfcc` split the first element on every one. A client whose Subject DN carries semicolons could contribute its own `Cert=` or `Chain=` pair and have it override the one Envoy wrote, authenticating the request as an arbitrary certificate.

- Comma and semicolon splits now share one quote-aware scanner
- An element carrying `Cert=` or `Chain=` twice is rejected

Reachable where Envoy is configured to emit `Subject` in `set_current_client_cert_details` and the client holds a certificate from a trusted CA with a semicolon in its DN. Present since the XFCC parser was added; backport to `maint/1.x` in a separate PR.